### PR TITLE
Fixed unit and integration tests that break in other environments.

### DIFF
--- a/Mittons.Fixtures.Tests.Integration/Docker/Gateways/DefaultDockerGatewayTests.cs
+++ b/Mittons.Fixtures.Tests.Integration/Docker/Gateways/DefaultDockerGatewayTests.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.IO;
 using System.Text.Json;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 {
@@ -393,6 +394,18 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 var containerId = gateway.ContainerRun("atmoz/sftp:alpine", "guest:guest", new Dictionary<string, string>());
                 _containerIds.Add(containerId);
+
+                for (var i = 0; i < 10; ++i)
+                {
+                    var health = gateway.ContainerExecuteCommand(containerId, "ps aux | grep -v grep | grep sshd || exit 1");
+
+                    if (health.Any())
+                    {
+                        break;
+                    }
+
+                    Task.Delay(1000).GetAwaiter().GetResult();
+                }
 
                 // Act
                 var results = gateway.ContainerExecuteCommand(containerId, "ssh-keygen -l -E md5 -f /etc/ssh/ssh_host_rsa_key.pub");

--- a/Mittons.Fixtures.Tests.Unit/Docker/Containers/SftpContainerTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Containers/SftpContainerTests.cs
@@ -20,6 +20,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Containers
         {
             // Arrange
             var gatewayMock = new Mock<IDockerGateway>();
+            gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                .Returns(IPAddress.Any);
 
             // Act
             using var container = new SftpContainer(gatewayMock.Object, Enumerable.Empty<Attribute>());
@@ -33,6 +35,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Containers
         {
             // Arrange
             var gatewayMock = new Mock<IDockerGateway>();
+            gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                .Returns(IPAddress.Any);
 
             // Act
             using var container = new SftpContainer(gatewayMock.Object, Enumerable.Empty<Attribute>());
@@ -49,6 +53,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Containers
         {
             // Arrange
             var gatewayMock = new Mock<IDockerGateway>();
+            gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                .Returns(IPAddress.Any);
 
             // Act
             using var container = new SftpContainer(
@@ -68,6 +74,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Containers
         {
             // Arrange
             var gatewayMock = new Mock<IDockerGateway>();
+            gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                .Returns(IPAddress.Any);
 
             // Act
             using var container = new SftpContainer(

--- a/Mittons.Fixtures.Tests.Unit/Docker/Fixtures/DockerEnvironmentTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Fixtures/DockerEnvironmentTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using Mittons.Fixtures.Docker.Attributes;
 using Mittons.Fixtures.Docker.Containers;
 using Mittons.Fixtures.Docker.Fixtures;
@@ -98,6 +99,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
 
                 // Act
                 using var fixture = new BuildEnvironmentFixture(gatewayMock.Object);
@@ -114,6 +117,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
 
                 // Act
                 using var fixture = new ReleaseEnvironmentFixture(gatewayMock.Object);
@@ -130,6 +135,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
 
                 // Act
                 using var fixture = new UnsetEnvironmentFixture(gatewayMock.Object);
@@ -146,6 +153,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
 
                 // Act
                 using var fixture = new MissingEnvironmentFixture(gatewayMock.Object);
@@ -179,6 +188,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
 
                 // Act
                 using var fixture = new ContainerTestEnvironmentFixture(gatewayMock.Object);
@@ -193,6 +204,9 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
+
                 gatewayMock.Setup(x => x.ContainerRun("alpine:3.15", string.Empty, It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")))).Returns("runningid");
                 gatewayMock.Setup(x => x.ContainerRun("redis:alpine", string.Empty, It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")))).Returns("disposingid");
 
@@ -236,6 +250,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
 
                 // Act
                 using var fixture = new SftpContainerTestEnvironmentFixture(gatewayMock.Object);
@@ -249,6 +265,9 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
+
                 gatewayMock.Setup(x => x.ContainerRun("atmoz/sftp:alpine", "guest:guest", It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")))).Returns("guest");
                 gatewayMock.Setup(x => x.ContainerRun("atmoz/sftp:alpine", "testuser1:testpassword1 testuser2:testpassword2", It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")))).Returns("account");
 
@@ -311,6 +330,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
 
                 // Act
                 using var fixture = new NetworkTestEnvironmentFixture(gatewayMock.Object);
@@ -325,6 +346,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
 
                 // Act
                 // Assert
@@ -336,6 +359,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
 
                 // Act
                 using var fixture1 = new NetworkTestEnvironmentFixture(gatewayMock.Object);
@@ -353,6 +378,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
 
                 // Act
                 using var fixture = new NetworkTestEnvironmentFixture(gatewayMock.Object);
@@ -376,6 +403,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
             {
                 // Arrange
                 var gatewayMock = new Mock<IDockerGateway>();
+                gatewayMock.Setup(x => x.ContainerGetDefaultNetworkIpAddress(It.IsAny<string>()))
+                    .Returns(IPAddress.Any);
 
                 // Act
                 using var fixture = new NetworkTestEnvironmentFixture(gatewayMock.Object);


### PR DESCRIPTION
* Fixed unit tests that needed IP Address mocks
* Fixed integration test that could fail if the docker exec was tried before the container was up

Fixes #26 