### PR TITLE
Reworked labels to be generic

### DIFF
--- a/Mittons.Fixtures.Tests.Integration/Docker/Gateways/DefaultDockerGatewayTests.cs
+++ b/Mittons.Fixtures.Tests.Integration/Docker/Gateways/DefaultDockerGatewayTests.cs
@@ -1,16 +1,16 @@
-using Xunit;
-using Mittons.Fixtures.Docker.Gateways;
-using Mittons.Fixtures.Extensions;
-using System.Diagnostics;
-using System.Text;
 using System;
 using System.Collections.Generic;
-using System.Net;
+using System.Diagnostics;
 using System.IO;
-using System.Text.Json;
 using System.Linq;
-using System.Threading.Tasks;
+using System.Net;
+using System.Text;
+using System.Text.Json;
 using System.Threading;
+using System.Threading.Tasks;
+using Mittons.Fixtures.Docker.Gateways;
+using Mittons.Fixtures.Extensions;
+using Xunit;
 
 namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 {
@@ -24,7 +24,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
             public void Dispose()
             {
-                foreach(var containerId in _containerIds)
+                foreach (var containerId in _containerIds)
                 {
                     using var proc = new Process();
                     proc.StartInfo.FileName = "docker";
@@ -36,7 +36,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                     proc.WaitForExit();
                 }
 
-                foreach(var filename in _filenames)
+                foreach (var filename in _filenames)
                 {
                     File.Delete(filename);
                 }
@@ -53,10 +53,10 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 var containerId = await gateway.ContainerRunAsync(
                         imageName,
                         string.Empty,
-                        new Dictionary<string, string>
+                        new List<KeyValuePair<string, string>>
                         {
-                            { "first", "second" },
-                            { "third", "fourth" }
+                            new KeyValuePair<string, string>("--label", "first=second"),
+                            new KeyValuePair<string, string>("--label", "third=fourth")
                         },
                         CancellationToken.None
                     );
@@ -77,10 +77,8 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 var actualLabels = JsonSerializer.Deserialize<Dictionary<string, string>>(output) ?? new Dictionary<string, string>();
 
-                Assert.True(actualLabels.ContainsKey("first"));
-                Assert.True(actualLabels.ContainsKey("third"));
-                Assert.Equal("second", actualLabels["first"]);
-                Assert.Equal("fourth", actualLabels["third"]);
+                Assert.Contains(actualLabels, x => x.Key == "first" && x.Value == "second");
+                Assert.Contains(actualLabels, x => x.Key == "third" && x.Value == "fourth");
             }
 
             [Theory]
@@ -92,7 +90,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 var gateway = new DefaultDockerGateway();
 
                 // Act
-                var containerId = await gateway.ContainerRunAsync(imageName, string.Empty, new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync(imageName, string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 // Assert
@@ -107,7 +105,8 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 var outputBuilder = new StringBuilder();
 
-                while (!proc.StandardOutput.EndOfStream) {
+                while (!proc.StandardOutput.EndOfStream)
+                {
                     outputBuilder.Append(proc.StandardOutput.ReadLine());
                 }
 
@@ -123,7 +122,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 var gateway = new DefaultDockerGateway();
 
                 // Act
-                var containerId = await gateway.ContainerRunAsync("alpine:3.15", string.Empty, new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("alpine:3.15", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 // Assert
@@ -138,7 +137,8 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 var outputBuilder = new StringBuilder();
 
-                while (!proc.StandardOutput.EndOfStream) {
+                while (!proc.StandardOutput.EndOfStream)
+                {
                     outputBuilder.Append(proc.StandardOutput.ReadLine());
                 }
 
@@ -154,7 +154,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 var gateway = new DefaultDockerGateway();
 
                 // Act
-                var containerId = await gateway.ContainerRunAsync("alpine:3.15", "/bin/bash", new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("alpine:3.15", "/bin/bash", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 // Assert
@@ -169,7 +169,8 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 var outputBuilder = new StringBuilder();
 
-                while (!proc.StandardOutput.EndOfStream) {
+                while (!proc.StandardOutput.EndOfStream)
+                {
                     outputBuilder.Append(proc.StandardOutput.ReadLine());
                 }
 
@@ -195,7 +196,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 // Arrange
                 var gateway = new DefaultDockerGateway();
 
-                var containerId = await gateway.ContainerRunAsync("alpine:3.15", string.Empty, new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("alpine:3.15", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 // Act
@@ -222,7 +223,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 // Arrange
                 var gateway = new DefaultDockerGateway();
 
-                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 // Act
@@ -258,7 +259,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 var gateway = new DefaultDockerGateway();
 
-                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 // Act
@@ -294,7 +295,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 var gateway = new DefaultDockerGateway();
 
-                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 // Act
@@ -330,7 +331,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 var gateway = new DefaultDockerGateway();
 
-                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 // Act
@@ -366,7 +367,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 var gateway = new DefaultDockerGateway();
 
-                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 await gateway.ContainerAddFileAsync(containerId, temporaryFilename, containerFilename, default(string), default(string), CancellationToken.None);
@@ -395,7 +396,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 // Arrange
                 var gateway = new DefaultDockerGateway();
 
-                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 for (var i = 0; i < 10; ++i)
@@ -435,7 +436,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 // Arrange
                 var gateway = new DefaultDockerGateway();
 
-                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 // Act
@@ -462,7 +463,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 // Arrange
                 var gateway = new DefaultDockerGateway();
 
-                var containerId = await gateway.ContainerRunAsync("redis:alpine", string.Empty, new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("redis:alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 // Act
@@ -491,7 +492,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 public void Dispose()
                 {
-                    foreach(var containerId in _containerIds)
+                    foreach (var containerId in _containerIds)
                     {
                         using var proc = new Process();
                         proc.StartInfo.FileName = "docker";
@@ -510,7 +511,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                     // Arrange
                     var gateway = new DefaultDockerGateway();
 
-                    var containerId = await gateway.ContainerRunAsync("redis:alpine", string.Empty, new Dictionary<string, string>(), CancellationToken.None);
+                    var containerId = await gateway.ContainerRunAsync("redis:alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                     _containerIds.Add(containerId);
 
                     // Act
@@ -526,7 +527,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                     // Arrange
                     var gateway = new DefaultDockerGateway();
 
-                    var containerId = await gateway.ContainerRunAsync("--health-cmd=\"echo hello\" --health-interval=1s redis:alpine", string.Empty, new Dictionary<string, string>(), CancellationToken.None);
+                    var containerId = await gateway.ContainerRunAsync("--health-cmd=\"echo hello\" --health-interval=1s redis:alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                     _containerIds.Add(containerId);
 
                     // Act
@@ -543,7 +544,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                     // Arrange
                     var gateway = new DefaultDockerGateway();
 
-                    var containerId = await gateway.ContainerRunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, new Dictionary<string, string>(), CancellationToken.None);
+                    var containerId = await gateway.ContainerRunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                     _containerIds.Add(containerId);
 
                     // Act
@@ -560,7 +561,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                     // Arrange
                     var gateway = new DefaultDockerGateway();
 
-                    var containerId = await gateway.ContainerRunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, new Dictionary<string, string>(), CancellationToken.None);
+                    var containerId = await gateway.ContainerRunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                     _containerIds.Add(containerId);
 
                     // Act
@@ -576,7 +577,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                     // Arrange
                     var gateway = new DefaultDockerGateway();
 
-                    var containerId = await gateway.ContainerRunAsync("alpine", string.Empty, new Dictionary<string, string>(), CancellationToken.None);
+                    var containerId = await gateway.ContainerRunAsync("alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                     _containerIds.Add(containerId);
 
                     // Act
@@ -596,7 +597,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
             public void Dispose()
             {
-                foreach(var containerId in _containerIds)
+                foreach (var containerId in _containerIds)
                 {
                     using var proc = new Process();
                     proc.StartInfo.FileName = "docker";
@@ -608,7 +609,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                     proc.WaitForExit();
                 }
 
-                foreach(var networkName in _networkNames)
+                foreach (var networkName in _networkNames)
                 {
                     using var proc = new Process();
                     proc.StartInfo.FileName = "docker";
@@ -633,7 +634,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 _networkNames.Add(uniqueName);
 
                 // Act
-                await gateway.NetworkCreateAsync(uniqueName, new Dictionary<string, string>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
+                await gateway.NetworkCreateAsync(uniqueName, Enumerable.Empty<KeyValuePair<string, string>>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
 
                 // Assert
                 using var proc = new Process();
@@ -657,10 +658,10 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 var networkName = "test";
                 var uniqueName = $"{networkName}-{Guid.NewGuid()}";
 
-                var expectedLabels = new Dictionary<string, string>
+                var expectedOptions = new KeyValuePair<string, string>[]
                 {
-                    { "first", "second" },
-                    { "third", "fourth" }
+                    new KeyValuePair<string, string>("--label", "first=second"),
+                    new KeyValuePair<string, string>("--label", "third=fourth")
                 };
 
                 var gateway = new DefaultDockerGateway();
@@ -668,7 +669,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
                 _networkNames.Add(uniqueName);
 
                 // Act
-                await gateway.NetworkCreateAsync(uniqueName, expectedLabels, (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
+                await gateway.NetworkCreateAsync(uniqueName, expectedOptions, (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
 
                 // Assert
                 using var proc = new Process();
@@ -684,10 +685,8 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 var actualLabels = JsonSerializer.Deserialize<Dictionary<string, string>>(output) ?? new Dictionary<string, string>();
 
-                Assert.True(actualLabels.ContainsKey("first"));
-                Assert.True(actualLabels.ContainsKey("third"));
-                Assert.Equal(expectedLabels["first"], actualLabels["first"]);
-                Assert.Equal(expectedLabels["third"], actualLabels["third"]);
+                Assert.Contains(actualLabels, x => x.Key == "first" && x.Value == "second");
+                Assert.Contains(actualLabels, x => x.Key == "third" && x.Value == "fourth");
             }
 
             [Fact]
@@ -701,7 +700,7 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 _networkNames.Add(uniqueName);
 
-                await gateway.NetworkCreateAsync(uniqueName, new Dictionary<string, string>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
+                await gateway.NetworkCreateAsync(uniqueName, Enumerable.Empty<KeyValuePair<string, string>>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
 
                 // Act
                 await gateway.NetworkRemoveAsync(uniqueName, CancellationToken.None);
@@ -730,12 +729,12 @@ namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways
 
                 var gateway = new DefaultDockerGateway();
 
-                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", new Dictionary<string, string>(), CancellationToken.None);
+                var containerId = await gateway.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
                 _containerIds.Add(containerId);
 
                 _networkNames.Add(uniqueName);
 
-                await gateway.NetworkCreateAsync(uniqueName, new Dictionary<string, string>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
+                await gateway.NetworkCreateAsync(uniqueName, Enumerable.Empty<KeyValuePair<string, string>>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
 
                 // Act
                 await gateway.NetworkConnectAsync(uniqueName, containerId, "test.example.com", CancellationToken.None);

--- a/Mittons.Fixtures.Tests.Unit/Docker/Containers/SftpContainerTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Containers/SftpContainerTests.cs
@@ -1,15 +1,15 @@
-using Xunit;
-using Moq;
-using Mittons.Fixtures.Docker.Gateways;
-using Mittons.Fixtures.Docker.Containers;
-using System.Linq;
 using System;
-using Mittons.Fixtures.Docker.Attributes;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using System.Linq;
 using System.Net;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Mittons.Fixtures.Docker.Attributes;
+using Mittons.Fixtures.Docker.Containers;
+using Mittons.Fixtures.Docker.Gateways;
+using Moq;
+using Xunit;
 
 namespace Mittons.Fixtures.Tests.Unit.Docker.Containers
 {
@@ -21,7 +21,7 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Containers
 
         public async ValueTask DisposeAsync()
         {
-            foreach(var container in _containers)
+            foreach (var container in _containers)
             {
                 await container.DisposeAsync();
             }
@@ -44,7 +44,7 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Containers
             await container.InitializeAsync();
 
             // Assert
-            gatewayMock.Verify(x => x.ContainerRunAsync(sftpImageName, It.IsAny<string>(), It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
+            gatewayMock.Verify(x => x.ContainerRunAsync(sftpImageName, It.IsAny<string>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Containers
             await container.InitializeAsync();
 
             // Assert
-            gatewayMock.Verify(x => x.ContainerRunAsync(sftpImageName, "guest:guest", It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
+            gatewayMock.Verify(x => x.ContainerRunAsync(sftpImageName, "guest:guest", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Theory]
@@ -94,7 +94,7 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Containers
             await container.InitializeAsync();
 
             // Assert
-            gatewayMock.Verify(x => x.ContainerRunAsync(sftpImageName, $"{username}:{password}", It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
+            gatewayMock.Verify(x => x.ContainerRunAsync(sftpImageName, $"{username}:{password}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -123,7 +123,7 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Containers
             await container.InitializeAsync();
 
             // Assert
-            gatewayMock.Verify(x => x.ContainerRunAsync(sftpImageName, $"testuser1:testpassword1 testuser2:testpassword2 guest:guest", It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
+            gatewayMock.Verify(x => x.ContainerRunAsync(sftpImageName, $"testuser1:testpassword1 testuser2:testpassword2 guest:guest", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -296,7 +296,7 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Containers
             // Assert
             Assert.Equal(accounts.Length, container.SftpConnectionSettings.Count);
 
-            foreach(var account in accounts)
+            foreach (var account in accounts)
             {
                 Assert.True(container.SftpConnectionSettings.ContainsKey(account.Username));
 

--- a/Mittons.Fixtures.Tests.Unit/Docker/Fixtures/DockerEnvironmentTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Fixtures/DockerEnvironmentTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -123,10 +124,40 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
                 await fixture.InitializeAsync();
 
                 // Assert
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network1-{fixture.InstanceId}", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == _buildId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network2-{fixture.InstanceId}", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == _buildId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.ContainerRunAsync("alpine:3.15", "", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == _buildId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.ContainerRunAsync("redis:alpine", "", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == _buildId), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(
+                        x => x.NetworkCreateAsync(
+                            $"network1-{fixture.InstanceId}",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.NetworkCreateAsync(
+                            $"network2-{fixture.InstanceId}",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.ContainerRunAsync(
+                            "alpine:3.15",
+                            "",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.ContainerRunAsync(
+                            "redis:alpine",
+                            "",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
             }
 
             [Fact]
@@ -146,10 +177,40 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
                 await fixture.InitializeAsync();
 
                 // Assert
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network1-{fixture.InstanceId}", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == _releaseId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network2-{fixture.InstanceId}", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == _releaseId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.ContainerRunAsync("alpine:3.15", "", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == _releaseId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.ContainerRunAsync("redis:alpine", "", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == _releaseId), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(
+                        x => x.NetworkCreateAsync(
+                            $"network1-{fixture.InstanceId}",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.NetworkCreateAsync(
+                            $"network2-{fixture.InstanceId}",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.ContainerRunAsync(
+                            "alpine:3.15",
+                            "",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.ContainerRunAsync(
+                            "redis:alpine",
+                            "",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
             }
 
             [Fact]
@@ -169,10 +230,40 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
                 await fixture.InitializeAsync();
 
                 // Assert
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network1-{fixture.InstanceId}", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == Run.DefaultId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network2-{fixture.InstanceId}", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == Run.DefaultId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.ContainerRunAsync("alpine:3.15", "", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == Run.DefaultId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.ContainerRunAsync("redis:alpine", "", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == Run.DefaultId), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(
+                        x => x.NetworkCreateAsync(
+                            $"network1-{fixture.InstanceId}",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={Run.DefaultId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.NetworkCreateAsync(
+                            $"network2-{fixture.InstanceId}",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={Run.DefaultId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.ContainerRunAsync(
+                            "alpine:3.15",
+                            "",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={Run.DefaultId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.ContainerRunAsync(
+                            "redis:alpine",
+                            "",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={Run.DefaultId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
             }
 
             [Fact]
@@ -192,10 +283,40 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
                 await fixture.InitializeAsync();
 
                 // Assert
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network1-{fixture.InstanceId}", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == Run.DefaultId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network2-{fixture.InstanceId}", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == Run.DefaultId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.ContainerRunAsync("alpine:3.15", "", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == Run.DefaultId), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.ContainerRunAsync("redis:alpine", "", It.Is<Dictionary<string, string>>(y => y["mittons.fixtures.run.id"] == Run.DefaultId), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(
+                        x => x.NetworkCreateAsync(
+                            $"network1-{fixture.InstanceId}",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={Run.DefaultId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.NetworkCreateAsync(
+                            $"network2-{fixture.InstanceId}",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={Run.DefaultId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.ContainerRunAsync(
+                            "alpine:3.15",
+                            "",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={Run.DefaultId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
+                gatewayMock.Verify(
+                        x => x.ContainerRunAsync(
+                            "redis:alpine",
+                            "",
+                            It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={Run.DefaultId}")),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Once
+                    );
             }
         }
 
@@ -242,8 +363,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
                 await fixture.InitializeAsync();
 
                 // Assert
-                gatewayMock.Verify(x => x.ContainerRunAsync("alpine:3.15", string.Empty, It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.ContainerRunAsync("redis:alpine", string.Empty, It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(x => x.ContainerRunAsync("alpine:3.15", string.Empty, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(x => x.ContainerRunAsync("redis:alpine", string.Empty, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
             }
 
             [Fact]
@@ -256,8 +377,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
                 gatewayMock.Setup(x => x.ContainerGetHealthStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(HealthStatus.Healthy);
 
-                gatewayMock.Setup(x => x.ContainerRunAsync("alpine:3.15", string.Empty, It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>())).ReturnsAsync("runningid");
-                gatewayMock.Setup(x => x.ContainerRunAsync("redis:alpine", string.Empty, It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>())).ReturnsAsync("disposingid");
+                gatewayMock.Setup(x => x.ContainerRunAsync("alpine:3.15", string.Empty, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>())).ReturnsAsync("runningid");
+                gatewayMock.Setup(x => x.ContainerRunAsync("redis:alpine", string.Empty, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>())).ReturnsAsync("disposingid");
 
                 var fixture = new ContainerTestEnvironmentFixture(gatewayMock.Object);
                 _fixtures.Add(fixture);
@@ -324,7 +445,7 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
                 await fixture.InitializeAsync();
 
                 // Assert
-                gatewayMock.Verify(x => x.ContainerRunAsync("atmoz/sftp:alpine", It.IsAny<string>(), It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Exactly(2));
+                gatewayMock.Verify(x => x.ContainerRunAsync("atmoz/sftp:alpine", It.IsAny<string>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
             }
 
             [Fact]
@@ -337,8 +458,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
                 gatewayMock.Setup(x => x.ContainerGetHealthStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(HealthStatus.Healthy);
 
-                gatewayMock.Setup(x => x.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>())).ReturnsAsync("guest");
-                gatewayMock.Setup(x => x.ContainerRunAsync("atmoz/sftp:alpine", "testuser1:testpassword1 testuser2:testpassword2", It.Is<Dictionary<string, string>>(x => x.Count == 1 && x.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>())).ReturnsAsync("account");
+                gatewayMock.Setup(x => x.ContainerRunAsync("atmoz/sftp:alpine", "guest:guest", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>())).ReturnsAsync("guest");
+                gatewayMock.Setup(x => x.ContainerRunAsync("atmoz/sftp:alpine", "testuser1:testpassword1 testuser2:testpassword2", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>())).ReturnsAsync("account");
 
                 var fixture = new SftpContainerTestEnvironmentFixture(gatewayMock.Object);
                 _fixtures.Add(fixture);
@@ -424,8 +545,8 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
                 await fixture.InitializeAsync();
 
                 // Assert
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network1-{fixture.InstanceId}", It.Is<Dictionary<string, string>>(y => y.Count == 1 && y.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network2-{fixture.InstanceId}", It.Is<Dictionary<string, string>>(y => y.Count == 1 && y.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(x => x.NetworkCreateAsync($"network1-{fixture.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(x => x.NetworkCreateAsync($"network2-{fixture.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
             }
 
             [Fact]
@@ -463,10 +584,10 @@ namespace Mittons.Fixtures.Tests.Unit.Docker.Environments
                 await fixture2.InitializeAsync();
 
                 // Assert
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network1-{fixture1.InstanceId}", It.Is<Dictionary<string, string>>(y => y.Count == 1 && y.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network2-{fixture1.InstanceId}", It.Is<Dictionary<string, string>>(y => y.Count == 1 && y.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network1-{fixture2.InstanceId}", It.Is<Dictionary<string, string>>(y => y.Count == 1 && y.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
-                gatewayMock.Verify(x => x.NetworkCreateAsync($"network2-{fixture2.InstanceId}", It.Is<Dictionary<string, string>>(y => y.Count == 1 && y.ContainsKey("mittons.fixtures.run.id")), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(x => x.NetworkCreateAsync($"network1-{fixture1.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(x => x.NetworkCreateAsync($"network2-{fixture1.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(x => x.NetworkCreateAsync($"network1-{fixture2.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+                gatewayMock.Verify(x => x.NetworkCreateAsync($"network2-{fixture2.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
             }
 
             [Fact]

--- a/Mittons.Fixtures/Docker/Attributes/Run.cs
+++ b/Mittons.Fixtures/Docker/Attributes/Run.cs
@@ -10,9 +10,9 @@ namespace Mittons.Fixtures.Docker.Attributes
 
         public string Id { get; }
 
-        public Dictionary<string, string> Labels => new Dictionary<string, string>
+        public KeyValuePair<string, string>[] Options => new[]
         {
-            { "mittons.fixtures.run.id", Id }
+            new KeyValuePair<string, string>("--label", $"mittons.fixtures.run.id={Id}")
         };
 
         public Run()

--- a/Mittons.Fixtures/Docker/Containers/Container.cs
+++ b/Mittons.Fixtures/Docker/Containers/Container.cs
@@ -25,7 +25,7 @@ namespace Mittons.Fixtures.Docker.Containers
 
         private readonly Guid _instanceId;
 
-        private readonly Dictionary<string, string> _labels;
+        private readonly KeyValuePair<string, string>[] _options;
 
         private readonly IEnumerable<NetworkAlias> _networks;
 
@@ -39,14 +39,14 @@ namespace Mittons.Fixtures.Docker.Containers
 
             _command = attributes.OfType<Command>().SingleOrDefault()?.Value ?? string.Empty;
 
-            _labels = (attributes.OfType<Run>().SingleOrDefault() ?? new Run()).Labels;
+            _options = (attributes.OfType<Run>().SingleOrDefault() ?? new Run()).Options;
 
             _networks = attributes.OfType<NetworkAlias>();
         }
 
         public virtual async Task InitializeAsync()
         {
-            Id = await _dockerGateway.ContainerRunAsync(_imageName, _command, _labels, CancellationToken.None);
+            Id = await _dockerGateway.ContainerRunAsync(_imageName, _command, _options, CancellationToken.None);
             IpAddress = await _dockerGateway.ContainerGetDefaultNetworkIpAddressAsync(Id, CancellationToken.None);
 
             await EnsureHealthyAsync(TimeSpan.FromSeconds(5));

--- a/Mittons.Fixtures/Docker/Fixtures/DockerEnvironmentFixture.cs
+++ b/Mittons.Fixtures/Docker/Fixtures/DockerEnvironmentFixture.cs
@@ -37,7 +37,7 @@ namespace Mittons.Fixtures.Docker.Fixtures
                 throw new NotSupportedException($"Networks with the same name cannot be created for the same environment. The following networks were duplicated: [{string.Join(", ", duplicateNetworks.Select(x => x.Key))}]");
             }
 
-            _networks = networks.Select(x => new DefaultNetwork(dockerGateway, $"{x.Name}-{InstanceId}", run.Labels)).ToArray();
+            _networks = networks.Select(x => new DefaultNetwork(dockerGateway, $"{x.Name}-{InstanceId}", run.Options)).ToArray();
 
             _containers = new List<Container>();
 

--- a/Mittons.Fixtures/Docker/Gateways/DefaultDockerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/DefaultDockerGateway.cs
@@ -13,11 +13,11 @@ namespace Mittons.Fixtures.Docker.Gateways
     {
         private static TimeSpan _defaultTimeout = TimeSpan.FromSeconds(10);
 
-        public async Task<string> ContainerRunAsync(string imageName, string command, Dictionary<string, string> labels, CancellationToken cancellationToken)
+        public async Task<string> ContainerRunAsync(string imageName, string command, IEnumerable<KeyValuePair<string, string>> options, CancellationToken cancellationToken)
         {
-            var labelStrings = labels.Select(x => $"--label \"{x.Key}={x.Value}\"");
+            var formattedOptions = options.Select(x => $"{x.Key} \"{x.Value}\"");
 
-            using (var process = CreateDockerProcess($"run -P -d {string.Join(" ", labelStrings)} {imageName} {command}"))
+            using (var process = CreateDockerProcess($"run -P -d {string.Join(" ", formattedOptions)} {imageName} {command}"))
             {
                 await RunProcessAsync(process, cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
 
@@ -134,11 +134,11 @@ namespace Mittons.Fixtures.Docker.Gateways
             }
         }
 
-        public async Task NetworkCreateAsync(string networkName, Dictionary<string, string> labels, CancellationToken cancellationToken)
+        public async Task NetworkCreateAsync(string networkName, IEnumerable<KeyValuePair<string, string>> options, CancellationToken cancellationToken)
         {
-            var labelStrings = labels.Select(x => $"--label \"{x.Key}={x.Value}\"");
+            var formattedOptions = options.Select(x => $"{x.Key} \"{x.Value}\"");
 
-            using (var process = CreateDockerProcess($"network create {string.Join(" ", labelStrings)} {networkName}"))
+            using (var process = CreateDockerProcess($"network create {string.Join(" ", formattedOptions)} {networkName}"))
             {
                 await RunProcessAsync(process, cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
             }

--- a/Mittons.Fixtures/Docker/Gateways/IDockerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/IDockerGateway.cs
@@ -7,7 +7,7 @@ namespace Mittons.Fixtures.Docker.Gateways
 {
     public interface IDockerGateway
     {
-        Task<string> ContainerRunAsync(string imageName, string command, Dictionary<string, string> labels, CancellationToken cancellationToken);
+        Task<string> ContainerRunAsync(string imageName, string command, IEnumerable<KeyValuePair<string, string>> options, CancellationToken cancellationToken);
 
         Task ContainerRemoveAsync(string containerId, CancellationToken cancellationToken);
 
@@ -23,7 +23,7 @@ namespace Mittons.Fixtures.Docker.Gateways
 
         Task<HealthStatus> ContainerGetHealthStatusAsync(string containerId, CancellationToken cancellationToken);
 
-        Task NetworkCreateAsync(string networkName, Dictionary<string, string> labels, CancellationToken cancellationToken);
+        Task NetworkCreateAsync(string networkName, IEnumerable<KeyValuePair<string, string>> labels, CancellationToken cancellationToken);
 
         Task NetworkRemoveAsync(string networkName, CancellationToken cancellationToken);
 

--- a/Mittons.Fixtures/Docker/Networks/DefaultNetwork.cs
+++ b/Mittons.Fixtures/Docker/Networks/DefaultNetwork.cs
@@ -13,19 +13,19 @@ namespace Mittons.Fixtures.Docker.Networks
 
         private readonly string _name;
 
-        private readonly Dictionary<string, string> _labels;
+        private readonly IEnumerable<KeyValuePair<string, string>> _options;
 
-        public DefaultNetwork(IDockerGateway dockerGateway, string name, Dictionary<string, string> labels)
+        public DefaultNetwork(IDockerGateway dockerGateway, string name, IEnumerable<KeyValuePair<string, string>> options)
         {
             _dockerGateway = dockerGateway;
             _name = name;
-            _labels = labels;
+            _options = options;
         }
 
         public Task DisposeAsync()
             => _dockerGateway.NetworkRemoveAsync(_name, CancellationToken.None);
 
         public Task InitializeAsync()
-            => _dockerGateway.NetworkCreateAsync(_name, _labels, CancellationToken.None);
+            => _dockerGateway.NetworkCreateAsync(_name, _options, CancellationToken.None);
     }
 }


### PR DESCRIPTION
Reworked how labels are applied to they are taken in as generic options. This way, we won't need to keep adding new arguments every time we want to support a new docker option (like the 5 health check options we are about to take on).

Needed for #53 