### PR TITLE
Updating option key-value pairs to a new Option class.

### DIFF
--- a/Mittons.Fixtures.Tests.Integration/Docker/Gateways/ContainerGatewayTests.cs
+++ b/Mittons.Fixtures.Tests.Integration/Docker/Gateways/ContainerGatewayTests.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Mittons.Fixtures.Docker.Gateways;
 using Mittons.Fixtures.Extensions;
+using Mittons.Fixtures.Models;
 using Xunit;
 
 namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways;
@@ -51,10 +52,18 @@ public class ContainerGatewayTests : IDisposable
         var containerId = await containerGateway.RunAsync(
                 imageName,
                 string.Empty,
-                new List<KeyValuePair<string, string>>
+                new List<Option>
                 {
-                    new KeyValuePair<string, string>("--label", "first=second"),
-                    new KeyValuePair<string, string>("--label", "third=fourth")
+                    new Option
+                    {
+                        Name = "--label",
+                        Value = "first=second"
+                    },
+                    new Option
+                    {
+                        Name = "--label",
+                        Value = "third=fourth"
+                    }
                 },
                 CancellationToken.None
             );
@@ -88,7 +97,7 @@ public class ContainerGatewayTests : IDisposable
         var containerGateway = new ContainerGateway();
 
         // Act
-        var containerId = await containerGateway.RunAsync(imageName, string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync(imageName, string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         // Assert
@@ -120,7 +129,7 @@ public class ContainerGatewayTests : IDisposable
         var containerGateway = new ContainerGateway();
 
         // Act
-        var containerId = await containerGateway.RunAsync("alpine:3.15", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("alpine:3.15", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         // Assert
@@ -152,7 +161,7 @@ public class ContainerGatewayTests : IDisposable
         var containerGateway = new ContainerGateway();
 
         // Act
-        var containerId = await containerGateway.RunAsync("alpine:3.15", "/bin/bash", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("alpine:3.15", "/bin/bash", Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         // Assert
@@ -194,7 +203,7 @@ public class ContainerGatewayTests : IDisposable
         // Arrange
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("alpine:3.15", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("alpine:3.15", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         // Act
@@ -221,7 +230,7 @@ public class ContainerGatewayTests : IDisposable
         // Arrange
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         // Act
@@ -258,7 +267,7 @@ public class ContainerGatewayTests : IDisposable
 
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         // Act
@@ -294,7 +303,7 @@ public class ContainerGatewayTests : IDisposable
 
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         // Act
@@ -330,7 +339,7 @@ public class ContainerGatewayTests : IDisposable
 
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         // Act
@@ -366,7 +375,7 @@ public class ContainerGatewayTests : IDisposable
 
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         // Act
@@ -402,7 +411,7 @@ public class ContainerGatewayTests : IDisposable
 
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         await containerGateway.AddFileAsync(containerId, temporaryFilename, containerFilename, default(string), default(string), CancellationToken.None);
@@ -431,7 +440,7 @@ public class ContainerGatewayTests : IDisposable
         // Arrange
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         for (var i = 0; i < 10; ++i)
@@ -471,7 +480,7 @@ public class ContainerGatewayTests : IDisposable
         // Arrange
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         // Act
@@ -498,7 +507,7 @@ public class ContainerGatewayTests : IDisposable
         // Arrange
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("redis:alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("redis:alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         // Act
@@ -546,7 +555,7 @@ public class ContainerGatewayTests : IDisposable
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("redis:alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("redis:alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
             _containerIds.Add(containerId);
 
             // Act
@@ -562,7 +571,7 @@ public class ContainerGatewayTests : IDisposable
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("--health-cmd=\"echo hello\" --health-interval=1s redis:alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("--health-cmd=\"echo hello\" --health-interval=1s redis:alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
             _containerIds.Add(containerId);
 
             // Act
@@ -579,7 +588,7 @@ public class ContainerGatewayTests : IDisposable
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
             _containerIds.Add(containerId);
 
             // Act
@@ -596,7 +605,7 @@ public class ContainerGatewayTests : IDisposable
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
             _containerIds.Add(containerId);
 
             // Act
@@ -612,7 +621,7 @@ public class ContainerGatewayTests : IDisposable
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("alpine", string.Empty, Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
             _containerIds.Add(containerId);
 
             // Act

--- a/Mittons.Fixtures.Tests.Integration/Docker/Gateways/NetworkGatewayTests.cs
+++ b/Mittons.Fixtures.Tests.Integration/Docker/Gateways/NetworkGatewayTests.cs
@@ -81,7 +81,7 @@ public class NetworkGatewayTests
         var networkName = "test";
         var uniqueName = $"{networkName}-{Guid.NewGuid()}";
 
-        var expectedOptions = new Option[]
+        var expectedOptions = new List<Option>
         {
             new Option
             {

--- a/Mittons.Fixtures.Tests.Integration/Docker/Gateways/NetworkGatewayTests.cs
+++ b/Mittons.Fixtures.Tests.Integration/Docker/Gateways/NetworkGatewayTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Mittons.Fixtures.Docker.Gateways;
 using Mittons.Fixtures.Extensions;
+using Mittons.Fixtures.Models;
 using Xunit;
 
 namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways;
@@ -56,7 +57,7 @@ public class NetworkGatewayTests
         _networkNames.Add(uniqueName);
 
         // Act
-        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<KeyValuePair<string, string>>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
+        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<Option>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
 
         // Assert
         using var proc = new Process();
@@ -80,10 +81,18 @@ public class NetworkGatewayTests
         var networkName = "test";
         var uniqueName = $"{networkName}-{Guid.NewGuid()}";
 
-        var expectedOptions = new KeyValuePair<string, string>[]
+        var expectedOptions = new Option[]
         {
-            new KeyValuePair<string, string>("--label", "first=second"),
-            new KeyValuePair<string, string>("--label", "third=fourth")
+            new Option
+            {
+                Name = "--label",
+                Value = "first=second"
+            },
+            new Option
+            {
+                Name = "--label",
+                Value = "third=fourth"
+            }
         };
 
         var networkGateway = new NetworkGateway();
@@ -122,7 +131,7 @@ public class NetworkGatewayTests
 
         _networkNames.Add(uniqueName);
 
-        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<KeyValuePair<string, string>>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
+        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<Option>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
 
         // Act
         await networkGateway.RemoveAsync(uniqueName, CancellationToken.None);
@@ -152,12 +161,12 @@ public class NetworkGatewayTests
         var networkGateway = new NetworkGateway();
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<KeyValuePair<string, string>>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
         _containerIds.Add(containerId);
 
         _networkNames.Add(uniqueName);
 
-        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<KeyValuePair<string, string>>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
+        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<Option>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
 
         // Act
         await networkGateway.ConnectAsync(uniqueName, containerId, "test.example.com", CancellationToken.None);

--- a/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Mittons.Fixtures.Docker.Attributes;
 using Mittons.Fixtures.Docker.Containers;
 using Mittons.Fixtures.Docker.Gateways;
+using Mittons.Fixtures.Models;
 using Moq;
 using Xunit;
 
@@ -40,7 +41,7 @@ public class ContainerTests : BaseContainerTests
                 await container.InitializeAsync(CancellationToken.None);
 
                 // Assert
-                containerGatewayMock.Verify(x => x.RunAsync(imageName, string.Empty, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+                containerGatewayMock.Verify(x => x.RunAsync(imageName, string.Empty, It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
             }
         }
 
@@ -65,7 +66,7 @@ public class ContainerTests : BaseContainerTests
                 await container.InitializeAsync(CancellationToken.None);
 
                 // Assert
-                containerGatewayMock.Verify(x => x.RunAsync(string.Empty, command, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+                containerGatewayMock.Verify(x => x.RunAsync(string.Empty, command, It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
             }
         }
 
@@ -127,7 +128,7 @@ public class ContainerTests : BaseContainerTests
                         x.RunAsync(
                             string.Empty,
                             string.Empty,
-                            It.Is<IEnumerable<KeyValuePair<string, string>>>(x => x.Any(y => y.Key == "--label" && y.Value == $"mittons.fixtures.run.id={run.Id}")),
+                            It.Is<IEnumerable<Option>>(x => x.Any(y => y.Name == "--label" && y.Value == $"mittons.fixtures.run.id={run.Id}")),
                             It.IsAny<CancellationToken>()
                         )
                     );
@@ -236,7 +237,7 @@ public class ContainerTests : BaseContainerTests
                         x.RunAsync(
                             string.Empty,
                             string.Empty,
-                            It.Is<IEnumerable<KeyValuePair<string, string>>>(x => x.Any(y => y.Key == "--no-healthcheck" && y.Value == string.Empty)),
+                            It.Is<IEnumerable<Option>>(x => x.Any(y => y.Name == "--no-healthcheck" && y.Value == string.Empty)),
                             It.IsAny<CancellationToken>()
                         )
                     );
@@ -282,13 +283,13 @@ public class ContainerTests : BaseContainerTests
                         x.RunAsync(
                             string.Empty,
                             string.Empty,
-                            It.Is<IEnumerable<KeyValuePair<string, string>>>(x =>
-                                x.Any(y => y.Key == "--no-healthcheck") &&
-                                !x.Any(y => y.Key == "--health-cmd") &&
-                                !x.Any(y => y.Key == "--health-interval") &&
-                                !x.Any(y => y.Key == "--health-timeout") &&
-                                !x.Any(y => y.Key == "--health-start-period") &&
-                                !x.Any(y => y.Key == "--health-retries")
+                            It.Is<IEnumerable<Option>>(x =>
+                                x.Any(y => y.Name == "--no-healthcheck") &&
+                                !x.Any(y => y.Name == "--health-cmd") &&
+                                !x.Any(y => y.Name == "--health-interval") &&
+                                !x.Any(y => y.Name == "--health-timeout") &&
+                                !x.Any(y => y.Name == "--health-start-period") &&
+                                !x.Any(y => y.Name == "--health-retries")
                             ),
                             It.IsAny<CancellationToken>()
                         )
@@ -329,7 +330,7 @@ public class ContainerTests : BaseContainerTests
                         x.RunAsync(
                             string.Empty,
                             string.Empty,
-                            It.Is<IEnumerable<KeyValuePair<string, string>>>(x => x.Any(y => y.Key == "--health-cmd" && y.Value == command)),
+                            It.Is<IEnumerable<Option>>(x => x.Any(y => y.Name == "--health-cmd" && y.Value == command)),
                             It.IsAny<CancellationToken>()
                         )
                     );
@@ -372,7 +373,7 @@ public class ContainerTests : BaseContainerTests
                         x.RunAsync(
                             string.Empty,
                             string.Empty,
-                            It.Is<IEnumerable<KeyValuePair<string, string>>>(x => x.Any(y => y.Key == "--health-interval" && y.Value == $"{seconds}s")),
+                            It.Is<IEnumerable<Option>>(x => x.Any(y => y.Name == "--health-interval" && y.Value == $"{seconds}s")),
                             It.IsAny<CancellationToken>()
                         )
                     );
@@ -415,7 +416,7 @@ public class ContainerTests : BaseContainerTests
                         x.RunAsync(
                             string.Empty,
                             string.Empty,
-                            It.Is<IEnumerable<KeyValuePair<string, string>>>(x => x.Any(y => y.Key == "--health-timeout" && y.Value == $"{seconds}s")),
+                            It.Is<IEnumerable<Option>>(x => x.Any(y => y.Name == "--health-timeout" && y.Value == $"{seconds}s")),
                             It.IsAny<CancellationToken>()
                         )
                     );
@@ -458,7 +459,7 @@ public class ContainerTests : BaseContainerTests
                         x.RunAsync(
                             string.Empty,
                             string.Empty,
-                            It.Is<IEnumerable<KeyValuePair<string, string>>>(x => x.Any(y => y.Key == "--health-start-period" && y.Value == $"{seconds}s")),
+                            It.Is<IEnumerable<Option>>(x => x.Any(y => y.Name == "--health-start-period" && y.Value == $"{seconds}s")),
                             It.IsAny<CancellationToken>()
                         )
                     );
@@ -499,7 +500,7 @@ public class ContainerTests : BaseContainerTests
                         x.RunAsync(
                             string.Empty,
                             string.Empty,
-                            It.Is<IEnumerable<KeyValuePair<string, string>>>(x => x.Any(y => y.Key == "--health-retries" && y.Value == retries.ToString())),
+                            It.Is<IEnumerable<Option>>(x => x.Any(y => y.Name == "--health-retries" && y.Value == retries.ToString())),
                             It.IsAny<CancellationToken>()
                         )
                     );
@@ -534,9 +535,9 @@ public class ContainerTests : BaseContainerTests
         {
             // Arrange
             var containerGatewayMock = new Mock<IContainerGateway>();
-            containerGatewayMock.Setup(x => x.RunAsync("runningimage", string.Empty, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()))
+            containerGatewayMock.Setup(x => x.RunAsync("runningimage", string.Empty, It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync("runningid");
-            containerGatewayMock.Setup(x => x.RunAsync("disposingimage", string.Empty, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()))
+            containerGatewayMock.Setup(x => x.RunAsync("disposingimage", string.Empty, It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync("disposingid");
             containerGatewayMock.Setup(x => x.GetHealthStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(HealthStatus.Healthy);

--- a/Mittons.Fixtures.Tests.Unit/Docker/Containers/SftpContainerTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Containers/SftpContainerTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Mittons.Fixtures.Docker.Attributes;
 using Mittons.Fixtures.Docker.Containers;
 using Mittons.Fixtures.Docker.Gateways;
+using Mittons.Fixtures.Models;
 using Moq;
 using Xunit;
 
@@ -48,13 +49,13 @@ public class SftpContainerTests : BaseContainerTests
                     x.RunAsync(
                         It.IsAny<string>(),
                         It.IsAny<string>(),
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(x =>
-                            !x.Any(y => y.Key == "--no-healthcheck") &&
-                            x.Any(y => y.Key == "--health-cmd" && y.Value == "ps aux | grep -v grep | grep sshd || exit 1") &&
-                            x.Any(y => y.Key == "--health-interval" && y.Value == "1s") &&
-                            x.Any(y => y.Key == "--health-timeout" && y.Value == "1s") &&
-                            x.Any(y => y.Key == "--health-start-period" && y.Value == "5s") &&
-                            x.Any(y => y.Key == "--health-retries" && y.Value == "3")
+                        It.Is<IEnumerable<Option>>(x =>
+                            !x.Any(y => y.Name == "--no-healthcheck") &&
+                            x.Any(y => y.Name == "--health-cmd" && y.Value == "ps aux | grep -v grep | grep sshd || exit 1") &&
+                            x.Any(y => y.Name == "--health-interval" && y.Value == "1s") &&
+                            x.Any(y => y.Name == "--health-timeout" && y.Value == "1s") &&
+                            x.Any(y => y.Name == "--health-start-period" && y.Value == "5s") &&
+                            x.Any(y => y.Name == "--health-retries" && y.Value == "3")
                         ),
                         It.IsAny<CancellationToken>()
                     )
@@ -101,13 +102,13 @@ public class SftpContainerTests : BaseContainerTests
                     x.RunAsync(
                         It.IsAny<string>(),
                         It.IsAny<string>(),
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(x =>
-                            !x.Any(y => y.Key == "--no-healthcheck") &&
-                            x.Any(y => y.Key == "--health-cmd" && y.Value == "test") &&
-                            x.Any(y => y.Key == "--health-interval" && y.Value == "2s") &&
-                            x.Any(y => y.Key == "--health-timeout" && y.Value == "2s") &&
-                            x.Any(y => y.Key == "--health-start-period" && y.Value == "2s") &&
-                            x.Any(y => y.Key == "--health-retries" && y.Value == "1")
+                        It.Is<IEnumerable<Option>>(x =>
+                            !x.Any(y => y.Name == "--no-healthcheck") &&
+                            x.Any(y => y.Name == "--health-cmd" && y.Value == "test") &&
+                            x.Any(y => y.Name == "--health-interval" && y.Value == "2s") &&
+                            x.Any(y => y.Name == "--health-timeout" && y.Value == "2s") &&
+                            x.Any(y => y.Name == "--health-start-period" && y.Value == "2s") &&
+                            x.Any(y => y.Name == "--health-retries" && y.Value == "1")
                         ),
                         It.IsAny<CancellationToken>()
                     )
@@ -138,7 +139,7 @@ public class SftpContainerTests : BaseContainerTests
             await container.InitializeAsync(CancellationToken.None);
 
             // Assert
-            containerGatewayMock.Verify(x => x.RunAsync(sftpImageName, It.IsAny<string>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+            containerGatewayMock.Verify(x => x.RunAsync(sftpImageName, It.IsAny<string>(), It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 
@@ -163,7 +164,7 @@ public class SftpContainerTests : BaseContainerTests
             await container.InitializeAsync(CancellationToken.None);
 
             // Assert
-            containerGatewayMock.Verify(x => x.RunAsync(It.IsAny<string>(), "guest:guest", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+            containerGatewayMock.Verify(x => x.RunAsync(It.IsAny<string>(), "guest:guest", It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Theory]
@@ -196,7 +197,7 @@ public class SftpContainerTests : BaseContainerTests
             await container.InitializeAsync(CancellationToken.None);
 
             // Assert
-            containerGatewayMock.Verify(x => x.RunAsync(It.IsAny<string>(), $"{username}:{password}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+            containerGatewayMock.Verify(x => x.RunAsync(It.IsAny<string>(), $"{username}:{password}", It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -228,7 +229,7 @@ public class SftpContainerTests : BaseContainerTests
             await container.InitializeAsync(CancellationToken.None);
 
             // Assert
-            containerGatewayMock.Verify(x => x.RunAsync(It.IsAny<string>(), $"testuser1:testpassword1 testuser2:testpassword2 guest:guest", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+            containerGatewayMock.Verify(x => x.RunAsync(It.IsAny<string>(), $"testuser1:testpassword1 testuser2:testpassword2 guest:guest", It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]

--- a/Mittons.Fixtures.Tests.Unit/Docker/Fixtures/DockerEnvironmentFixtureTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Fixtures/DockerEnvironmentFixtureTests.cs
@@ -8,6 +8,7 @@ using Mittons.Fixtures.Docker.Attributes;
 using Mittons.Fixtures.Docker.Containers;
 using Mittons.Fixtures.Docker.Fixtures;
 using Mittons.Fixtures.Docker.Gateways;
+using Mittons.Fixtures.Models;
 using Moq;
 using Xunit;
 
@@ -146,7 +147,7 @@ public class DockerEnvironmentFixtureTests
             networkGatewayMock.Verify(
                     x => x.CreateAsync(
                         $"network1-{fixture.InstanceId}",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -154,7 +155,7 @@ public class DockerEnvironmentFixtureTests
             networkGatewayMock.Verify(
                     x => x.CreateAsync(
                         $"network2-{fixture.InstanceId}",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -163,7 +164,7 @@ public class DockerEnvironmentFixtureTests
                     x => x.RunAsync(
                         "alpine:3.15",
                         "",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -172,7 +173,7 @@ public class DockerEnvironmentFixtureTests
                     x => x.RunAsync(
                         "redis:alpine",
                         "",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={_buildId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -201,7 +202,7 @@ public class DockerEnvironmentFixtureTests
             networkGatewayMock.Verify(
                     x => x.CreateAsync(
                         $"network1-{fixture.InstanceId}",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -209,7 +210,7 @@ public class DockerEnvironmentFixtureTests
             networkGatewayMock.Verify(
                     x => x.CreateAsync(
                         $"network2-{fixture.InstanceId}",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -218,7 +219,7 @@ public class DockerEnvironmentFixtureTests
                     x => x.RunAsync(
                         "alpine:3.15",
                         "",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -227,7 +228,7 @@ public class DockerEnvironmentFixtureTests
                     x => x.RunAsync(
                         "redis:alpine",
                         "",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={_releaseId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -256,7 +257,7 @@ public class DockerEnvironmentFixtureTests
             networkGatewayMock.Verify(
                     x => x.CreateAsync(
                         $"network1-{fixture.InstanceId}",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -264,7 +265,7 @@ public class DockerEnvironmentFixtureTests
             networkGatewayMock.Verify(
                     x => x.CreateAsync(
                         $"network2-{fixture.InstanceId}",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -273,7 +274,7 @@ public class DockerEnvironmentFixtureTests
                     x => x.RunAsync(
                         "alpine:3.15",
                         "",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -282,7 +283,7 @@ public class DockerEnvironmentFixtureTests
                     x => x.RunAsync(
                         "redis:alpine",
                         "",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -311,7 +312,7 @@ public class DockerEnvironmentFixtureTests
             networkGatewayMock.Verify(
                     x => x.CreateAsync(
                         $"network1-{fixture.InstanceId}",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -319,7 +320,7 @@ public class DockerEnvironmentFixtureTests
             networkGatewayMock.Verify(
                     x => x.CreateAsync(
                         $"network2-{fixture.InstanceId}",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -328,7 +329,7 @@ public class DockerEnvironmentFixtureTests
                     x => x.RunAsync(
                         "alpine:3.15",
                         "",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -337,7 +338,7 @@ public class DockerEnvironmentFixtureTests
                     x => x.RunAsync(
                         "redis:alpine",
                         "",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id={RunAttribute.DefaultId}")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -366,7 +367,7 @@ public class DockerEnvironmentFixtureTests
             networkGatewayMock.Verify(
                     x => x.CreateAsync(
                         $"network1-{fixture.InstanceId}",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id=test")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id=test")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -374,7 +375,7 @@ public class DockerEnvironmentFixtureTests
             networkGatewayMock.Verify(
                     x => x.CreateAsync(
                         $"network2-{fixture.InstanceId}",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id=test")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id=test")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -383,7 +384,7 @@ public class DockerEnvironmentFixtureTests
                     x => x.RunAsync(
                         "alpine:3.15",
                         "",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id=test")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id=test")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -392,7 +393,7 @@ public class DockerEnvironmentFixtureTests
                     x => x.RunAsync(
                         "redis:alpine",
                         "",
-                        It.Is<IEnumerable<KeyValuePair<string, string>>>(y => y.Any(z => z.Key == "--label" && z.Value == $"mittons.fixtures.run.id=test")),
+                        It.Is<IEnumerable<Option>>(y => y.Any(z => z.Name == "--label" && z.Value == $"mittons.fixtures.run.id=test")),
                         It.IsAny<CancellationToken>()
                     ),
                     Times.Once
@@ -602,8 +603,8 @@ public class DockerEnvironmentFixtureTests
             await fixture.InitializeAsync();
 
             // Assert
-            containerGatewayMock.Verify(x => x.RunAsync("alpine:3.15", string.Empty, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
-            containerGatewayMock.Verify(x => x.RunAsync("redis:alpine", string.Empty, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+            containerGatewayMock.Verify(x => x.RunAsync("alpine:3.15", string.Empty, It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
+            containerGatewayMock.Verify(x => x.RunAsync("redis:alpine", string.Empty, It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -616,8 +617,8 @@ public class DockerEnvironmentFixtureTests
             containerGatewayMock.Setup(x => x.GetHealthStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(HealthStatus.Healthy);
 
-            containerGatewayMock.Setup(x => x.RunAsync("alpine:3.15", string.Empty, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>())).ReturnsAsync("runningid");
-            containerGatewayMock.Setup(x => x.RunAsync("redis:alpine", string.Empty, It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>())).ReturnsAsync("disposingid");
+            containerGatewayMock.Setup(x => x.RunAsync("alpine:3.15", string.Empty, It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>())).ReturnsAsync("runningid");
+            containerGatewayMock.Setup(x => x.RunAsync("redis:alpine", string.Empty, It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>())).ReturnsAsync("disposingid");
 
             var networkGatewayMock = new Mock<INetworkGateway>();
 
@@ -688,7 +689,7 @@ public class DockerEnvironmentFixtureTests
             await fixture.InitializeAsync();
 
             // Assert
-            containerGatewayMock.Verify(x => x.RunAsync("atmoz/sftp:alpine", It.IsAny<string>(), It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            containerGatewayMock.Verify(x => x.RunAsync("atmoz/sftp:alpine", It.IsAny<string>(), It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
         [Fact]
@@ -701,8 +702,8 @@ public class DockerEnvironmentFixtureTests
             containerGatewayMock.Setup(x => x.GetHealthStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(HealthStatus.Healthy);
 
-            containerGatewayMock.Setup(x => x.RunAsync("atmoz/sftp:alpine", "guest:guest", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>())).ReturnsAsync("guest");
-            containerGatewayMock.Setup(x => x.RunAsync("atmoz/sftp:alpine", "testuser1:testpassword1 testuser2:testpassword2", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>())).ReturnsAsync("account");
+            containerGatewayMock.Setup(x => x.RunAsync("atmoz/sftp:alpine", "guest:guest", It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>())).ReturnsAsync("guest");
+            containerGatewayMock.Setup(x => x.RunAsync("atmoz/sftp:alpine", "testuser1:testpassword1 testuser2:testpassword2", It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>())).ReturnsAsync("account");
 
             var networkGatewayMock = new Mock<INetworkGateway>();
 
@@ -792,8 +793,8 @@ public class DockerEnvironmentFixtureTests
             await fixture.InitializeAsync();
 
             // Assert
-            networkGatewayMock.Verify(x => x.CreateAsync($"network1-{fixture.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
-            networkGatewayMock.Verify(x => x.CreateAsync($"network2-{fixture.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+            networkGatewayMock.Verify(x => x.CreateAsync($"network1-{fixture.InstanceId}", It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
+            networkGatewayMock.Verify(x => x.CreateAsync($"network2-{fixture.InstanceId}", It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -835,10 +836,10 @@ public class DockerEnvironmentFixtureTests
             await fixture2.InitializeAsync();
 
             // Assert
-            networkGatewayMock.Verify(x => x.CreateAsync($"network1-{fixture1.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
-            networkGatewayMock.Verify(x => x.CreateAsync($"network2-{fixture1.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
-            networkGatewayMock.Verify(x => x.CreateAsync($"network1-{fixture2.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
-            networkGatewayMock.Verify(x => x.CreateAsync($"network2-{fixture2.InstanceId}", It.IsAny<IEnumerable<KeyValuePair<string, string>>>(), It.IsAny<CancellationToken>()), Times.Once);
+            networkGatewayMock.Verify(x => x.CreateAsync($"network1-{fixture1.InstanceId}", It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
+            networkGatewayMock.Verify(x => x.CreateAsync($"network2-{fixture1.InstanceId}", It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
+            networkGatewayMock.Verify(x => x.CreateAsync($"network1-{fixture2.InstanceId}", It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
+            networkGatewayMock.Verify(x => x.CreateAsync($"network2-{fixture2.InstanceId}", It.IsAny<IEnumerable<Option>>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]

--- a/Mittons.Fixtures.Tests.Unit/Extensions/OptionExtensionsTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Extensions/OptionExtensionsTests.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mittons.Fixtures.Extensions;
+using Mittons.Fixtures.Models;
+using Xunit;
+
+namespace Mittons.Fixtures.Tests.Unit.Extensions;
+
+public class OptionExtensionsTests
+{
+    [Fact]
+    public void ToCommandFormattedString_WhenOptionIsNull_ExpectArgumentNullException()
+    {
+        Option stubOption = null;
+
+        Assert.Throws<ArgumentNullException>(() => stubOption.ToCommandFormattedString());
+    }
+
+    [Fact]
+    public void ToCommandFormattedString_WhenNameIsNull_ExpectArgumentNullException()
+    {
+        var stubOption = new Option
+        {
+            Name = null,
+            Value = "value"
+        };
+
+        Assert.Throws<ArgumentNullException>(() => stubOption.ToCommandFormattedString());
+    }
+
+    [Fact]
+    public void ToCommandFormattedString_WhenValueIsNull_ExpectArgumentNullException()
+    {
+        var stubOption = new Option
+        {
+            Name = "--option",
+            Value = null
+        };
+
+        Assert.Throws<ArgumentNullException>(() => stubOption.ToCommandFormattedString());
+    }
+
+    [Fact]
+    public void ToCommandFormattedString_WhenNameAndValueAreNotNull_ExpectCommandFormattedString()
+    {
+        var stubOption = new Option
+        {
+            Name = "--option",
+            Value = "value"
+        };
+
+        var commandFormattedString = stubOption.ToCommandFormattedString();
+
+        Assert.Equal("--option \"value\"", commandFormattedString);
+    }
+
+    [Fact]
+    public void ToCommandFormattedString_WhenOptionsIsNull_ExpectArgumentNullException()
+    {
+        IEnumerable<Option> stubOptions = null;
+
+        Assert.Throws<ArgumentNullException>(() => stubOptions.ToCommandFormattedString());
+    }
+
+    [Fact]
+    public void ToCommandFormattedString_WhenOptionsIsEmpty_ExpectEmptyString()
+    {
+        var stubOptions = Enumerable.Empty<Option>();
+
+        var commandFormattedString = stubOptions.ToCommandFormattedString();
+
+        Assert.Equal(String.Empty, commandFormattedString);
+    }
+
+    [Fact]
+    public void ToCommandFormattedString_WhenOptionsHasElement_ExpectCommandFormattedString()
+    {
+        var stubOptions = new List<Option>
+        {
+            new Option
+            {
+                Name = "--option",
+                Value = "value"
+            }
+        };
+
+        var commandFormattedString = stubOptions.ToCommandFormattedString();
+
+        Assert.Equal("--option \"value\"", commandFormattedString);
+    }
+
+    [Fact]
+    public void ToCommandFormattedString_WhenOptionsHasElements_ExpectCommandFormattedString()
+    {
+        var stubOptions = new List<Option>
+        {
+            new Option
+            {
+                Name = "--option",
+                Value = "value"
+            },
+            new Option
+            {
+                Name = "--option",
+                Value = "value"
+            }
+        };
+
+        var commandFormattedString = stubOptions.ToCommandFormattedString();
+
+        Assert.Equal("--option \"value\" --option \"value\"", commandFormattedString);
+    }
+}

--- a/Mittons.Fixtures.Tests.Unit/Extensions/OptionExtensionsTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Extensions/OptionExtensionsTests.cs
@@ -30,7 +30,7 @@ public class OptionExtensionsTests
     }
 
     [Fact]
-    public void ToExecutionParameterFormattedString_WhenValueIsNull_ExpectArgumentNullException()
+    public void ToExecutionParameterFormattedString_WhenValueIsNull_ExpectExecutionParameterFormattedStringWithOnlyName()
     {
         var stubOption = new Option
         {
@@ -38,11 +38,41 @@ public class OptionExtensionsTests
             Value = null
         };
 
-        Assert.Throws<ArgumentNullException>(() => stubOption.ToExecutionParameterFormattedString());
+        var commandFormattedString = stubOption.ToExecutionParameterFormattedString();
+
+        Assert.Equal("--option", commandFormattedString);
     }
 
     [Fact]
-    public void ToExecutionParameterFormattedString_WhenNameAndValueAreNotNull_ExpectCommandFormattedString()
+    public void ToExecutionParameterFormattedString_WhenValueIsEmptyString_ExpectExecutionParameterFormattedStringWithOnlyName()
+    {
+        var stubOption = new Option
+        {
+            Name = "--option",
+            Value = string.Empty
+        };
+
+        var commandFormattedString = stubOption.ToExecutionParameterFormattedString();
+
+        Assert.Equal("--option", commandFormattedString);
+    }
+
+    [Fact]
+    public void ToExecutionParameterFormattedString_WhenValueIsWhiteSpace_ExpectExecutionParameterFormattedStringWithOnlyName()
+    {
+        var stubOption = new Option
+        {
+            Name = "--option",
+            Value = " "
+        };
+
+        var commandFormattedString = stubOption.ToExecutionParameterFormattedString();
+
+        Assert.Equal("--option", commandFormattedString);
+    }
+
+    [Fact]
+    public void ToExecutionParameterFormattedString_WhenNameAndValueAreNotNull_ExpectExecutionParameterFormattedString()
     {
         var stubOption = new Option
         {
@@ -74,7 +104,7 @@ public class OptionExtensionsTests
     }
 
     [Fact]
-    public void ToExecutionParametersFormattedString_WhenOptionsHasElement_ExpectCommandFormattedString()
+    public void ToExecutionParametersFormattedString_WhenOptionsHasElement_ExpectExecutionParameterFormattedString()
     {
         var stubOptions = new Option[]
         {
@@ -91,7 +121,7 @@ public class OptionExtensionsTests
     }
 
     [Fact]
-    public void ToExecutionParametersFormattedString_WhenOptionsHasElements_ExpectCommandFormattedString()
+    public void ToExecutionParametersFormattedString_WhenOptionsHasElements_ExpectExecutionParameterFormattedString()
     {
         var stubOptions = new Option[]
         {

--- a/Mittons.Fixtures.Tests.Unit/Extensions/OptionExtensionsTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Extensions/OptionExtensionsTests.cs
@@ -10,15 +10,15 @@ namespace Mittons.Fixtures.Tests.Unit.Extensions;
 public class OptionExtensionsTests
 {
     [Fact]
-    public void ToCommandFormattedString_WhenOptionIsNull_ExpectArgumentNullException()
+    public void ToExecutionParameterFormattedString_WhenOptionIsNull_ExpectArgumentNullException()
     {
         Option stubOption = null;
 
-        Assert.Throws<ArgumentNullException>(() => stubOption.ToCommandFormattedString());
+        Assert.Throws<ArgumentNullException>(() => stubOption.ToExecutionParameterFormattedString());
     }
 
     [Fact]
-    public void ToCommandFormattedString_WhenNameIsNull_ExpectArgumentNullException()
+    public void ToExecutionParameterFormattedString_WhenNameIsNull_ExpectArgumentNullException()
     {
         var stubOption = new Option
         {
@@ -26,11 +26,11 @@ public class OptionExtensionsTests
             Value = "value"
         };
 
-        Assert.Throws<ArgumentNullException>(() => stubOption.ToCommandFormattedString());
+        Assert.Throws<ArgumentNullException>(() => stubOption.ToExecutionParameterFormattedString());
     }
 
     [Fact]
-    public void ToCommandFormattedString_WhenValueIsNull_ExpectArgumentNullException()
+    public void ToExecutionParameterFormattedString_WhenValueIsNull_ExpectArgumentNullException()
     {
         var stubOption = new Option
         {
@@ -38,11 +38,11 @@ public class OptionExtensionsTests
             Value = null
         };
 
-        Assert.Throws<ArgumentNullException>(() => stubOption.ToCommandFormattedString());
+        Assert.Throws<ArgumentNullException>(() => stubOption.ToExecutionParameterFormattedString());
     }
 
     [Fact]
-    public void ToCommandFormattedString_WhenNameAndValueAreNotNull_ExpectCommandFormattedString()
+    public void ToExecutionParameterFormattedString_WhenNameAndValueAreNotNull_ExpectCommandFormattedString()
     {
         var stubOption = new Option
         {
@@ -50,33 +50,33 @@ public class OptionExtensionsTests
             Value = "value"
         };
 
-        var commandFormattedString = stubOption.ToCommandFormattedString();
+        var commandFormattedString = stubOption.ToExecutionParameterFormattedString();
 
         Assert.Equal("--option \"value\"", commandFormattedString);
     }
 
     [Fact]
-    public void ToCommandFormattedString_WhenOptionsIsNull_ExpectArgumentNullException()
+    public void ToExecutionParametersFormattedString_WhenOptionsIsNull_ExpectArgumentNullException()
     {
         IEnumerable<Option> stubOptions = null;
 
-        Assert.Throws<ArgumentNullException>(() => stubOptions.ToCommandFormattedString());
+        Assert.Throws<ArgumentNullException>(() => stubOptions.ToExecutionParametersFormattedString());
     }
 
     [Fact]
-    public void ToCommandFormattedString_WhenOptionsIsEmpty_ExpectEmptyString()
+    public void ToExecutionParametersFormattedString_WhenOptionsIsEmpty_ExpectEmptyString()
     {
         var stubOptions = Enumerable.Empty<Option>();
 
-        var commandFormattedString = stubOptions.ToCommandFormattedString();
+        var commandFormattedString = stubOptions.ToExecutionParametersFormattedString();
 
-        Assert.Equal(String.Empty, commandFormattedString);
+        Assert.Equal(string.Empty, commandFormattedString);
     }
 
     [Fact]
-    public void ToCommandFormattedString_WhenOptionsHasElement_ExpectCommandFormattedString()
+    public void ToExecutionParametersFormattedString_WhenOptionsHasElement_ExpectCommandFormattedString()
     {
-        var stubOptions = new List<Option>
+        var stubOptions = new Option[]
         {
             new Option
             {
@@ -85,15 +85,15 @@ public class OptionExtensionsTests
             }
         };
 
-        var commandFormattedString = stubOptions.ToCommandFormattedString();
+        var commandFormattedString = stubOptions.ToExecutionParametersFormattedString();
 
         Assert.Equal("--option \"value\"", commandFormattedString);
     }
 
     [Fact]
-    public void ToCommandFormattedString_WhenOptionsHasElements_ExpectCommandFormattedString()
+    public void ToExecutionParametersFormattedString_WhenOptionsHasElements_ExpectCommandFormattedString()
     {
-        var stubOptions = new List<Option>
+        var stubOptions = new Option[]
         {
             new Option
             {
@@ -107,7 +107,7 @@ public class OptionExtensionsTests
             }
         };
 
-        var commandFormattedString = stubOptions.ToCommandFormattedString();
+        var commandFormattedString = stubOptions.ToExecutionParametersFormattedString();
 
         Assert.Equal("--option \"value\" --option \"value\"", commandFormattedString);
     }

--- a/Mittons.Fixtures/Docker/Attributes/HealthCheckAttribute.cs
+++ b/Mittons.Fixtures/Docker/Attributes/HealthCheckAttribute.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Mittons.Fixtures.Models;
 
 namespace Mittons.Fixtures.Docker.Attributes
 {
@@ -18,41 +19,41 @@ namespace Mittons.Fixtures.Docker.Attributes
 
         public int? Retries { get; set; }
 
-        public IEnumerable<KeyValuePair<string, string>> Options
+        public IEnumerable<Option> Options
         {
             get
             {
-                var options = new List<KeyValuePair<string, string>>();
+                var options = new List<Option>();
 
                 if (Disabled)
                 {
-                    options.Add(new KeyValuePair<string, string>("--no-healthcheck", string.Empty));
+                    options.Add(new Option { Name = "--no-healthcheck", Value = string.Empty });
                 }
                 else
                 {
                     if (!string.IsNullOrWhiteSpace(Command))
                     {
-                        options.Add(new KeyValuePair<string, string>("--health-cmd", Command));
+                        options.Add(new Option { Name = "--health-cmd", Value = Command });
                     }
 
                     if (Interval.HasValue)
                     {
-                        options.Add(new KeyValuePair<string, string>("--health-interval", $"{Math.Ceiling(Interval.Value.TotalSeconds)}s"));
+                        options.Add(new Option { Name = "--health-interval", Value = $"{Math.Ceiling(Interval.Value.TotalSeconds)}s" });
                     }
 
                     if (Timeout.HasValue)
                     {
-                        options.Add(new KeyValuePair<string, string>("--health-timeout", $"{Math.Ceiling(Timeout.Value.TotalSeconds)}s"));
+                        options.Add(new Option { Name = "--health-timeout", Value = $"{Math.Ceiling(Timeout.Value.TotalSeconds)}s" });
                     }
 
                     if (StartPeriod.HasValue)
                     {
-                        options.Add(new KeyValuePair<string, string>("--health-start-period", $"{Math.Ceiling(StartPeriod.Value.TotalSeconds)}s"));
+                        options.Add(new Option { Name = "--health-start-period", Value = $"{Math.Ceiling(StartPeriod.Value.TotalSeconds)}s" });
                     }
 
                     if (Retries.HasValue)
                     {
-                        options.Add(new KeyValuePair<string, string>("--health-retries", Retries.Value.ToString()));
+                        options.Add(new Option { Name = "--health-retries", Value = Retries.Value.ToString() });
                     }
                 }
 

--- a/Mittons.Fixtures/Docker/Attributes/IOptionAttribute.cs
+++ b/Mittons.Fixtures/Docker/Attributes/IOptionAttribute.cs
@@ -1,9 +1,10 @@
 using System.Collections.Generic;
+using Mittons.Fixtures.Models;
 
 namespace Mittons.Fixtures.Docker.Attributes
 {
     public interface IOptionAttribute
     {
-        IEnumerable<KeyValuePair<string, string>> Options { get; }
+        IEnumerable<Option> Options { get; }
     }
 }

--- a/Mittons.Fixtures/Docker/Attributes/RunAttribute.cs
+++ b/Mittons.Fixtures/Docker/Attributes/RunAttribute.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Mittons.Fixtures.Extensions;
+using Mittons.Fixtures.Models;
 
 namespace Mittons.Fixtures.Docker.Attributes
 {
@@ -13,9 +14,13 @@ namespace Mittons.Fixtures.Docker.Attributes
 
         public bool TeardownOnComplete { get; }
 
-        public IEnumerable<KeyValuePair<string, string>> Options => new[]
+        public IEnumerable<Option> Options => new List<Option>
         {
-            new KeyValuePair<string, string>("--label", $"mittons.fixtures.run.id={Id}")
+            new Option
+            {
+                Name = "--label",
+                Value = $"mittons.fixtures.run.id={Id}"
+            }
         };
 
         public RunAttribute()

--- a/Mittons.Fixtures/Docker/Containers/Container.cs
+++ b/Mittons.Fixtures/Docker/Containers/Container.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Mittons.Fixtures.Docker.Attributes;
 using Mittons.Fixtures.Docker.Gateways;
+using Mittons.Fixtures.Models;
 
 namespace Mittons.Fixtures.Docker.Containers
 {
@@ -26,7 +27,7 @@ namespace Mittons.Fixtures.Docker.Containers
 
         private readonly Guid _instanceId;
 
-        private readonly IEnumerable<KeyValuePair<string, string>> _options;
+        private readonly IEnumerable<Option> _options;
 
         private readonly IEnumerable<NetworkAliasAttribute> _networks;
 

--- a/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Mittons.Fixtures.Extensions;
+using Mittons.Fixtures.Models;
 
 namespace Mittons.Fixtures.Docker.Gateways
 {
@@ -13,11 +13,9 @@ namespace Mittons.Fixtures.Docker.Gateways
     {
         private static TimeSpan _defaultTimeout = TimeSpan.FromSeconds(10);
 
-        public async Task<string> RunAsync(string imageName, string command, IEnumerable<KeyValuePair<string, string>> options, CancellationToken cancellationToken)
+        public async Task<string> RunAsync(string imageName, string command, IEnumerable<Option> options, CancellationToken cancellationToken)
         {
-            var formattedOptions = options.Select(x => $"{x.Key} \"{x.Value}\"");
-
-            using (var process = new DockerProcess($"run -P -d {string.Join(" ", formattedOptions)} {imageName} {command}"))
+            using (var process = new DockerProcess($"run -P -d {options.ToCommandFormattedString()} {imageName} {command}"))
             {
                 await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
 

--- a/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
@@ -15,7 +15,7 @@ namespace Mittons.Fixtures.Docker.Gateways
 
         public async Task<string> RunAsync(string imageName, string command, IEnumerable<Option> options, CancellationToken cancellationToken)
         {
-            using (var process = new DockerProcess($"run -P -d {options.ToCommandFormattedString()} {imageName} {command}"))
+            using (var process = new DockerProcess($"run -P -d {options.ToExecutionParametersFormattedString()} {imageName} {command}"))
             {
                 await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
 

--- a/Mittons.Fixtures/Docker/Gateways/IContainerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/IContainerGateway.cs
@@ -2,12 +2,13 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using Mittons.Fixtures.Models;
 
 namespace Mittons.Fixtures.Docker.Gateways
 {
     public interface IContainerGateway
     {
-        Task<string> RunAsync(string imageName, string command, IEnumerable<KeyValuePair<string, string>> options, CancellationToken cancellationToken);
+        Task<string> RunAsync(string imageName, string command, IEnumerable<Option> options, CancellationToken cancellationToken);
 
         Task RemoveAsync(string containerId, CancellationToken cancellationToken);
 

--- a/Mittons.Fixtures/Docker/Gateways/INetworkGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/INetworkGateway.cs
@@ -1,12 +1,13 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Mittons.Fixtures.Models;
 
 namespace Mittons.Fixtures.Docker.Gateways
 {
     public interface INetworkGateway
     {
-        Task CreateAsync(string networkName, IEnumerable<KeyValuePair<string, string>> labels, CancellationToken cancellationToken);
+        Task CreateAsync(string networkName, IEnumerable<Option> options, CancellationToken cancellationToken);
 
         Task RemoveAsync(string networkName, CancellationToken cancellationToken);
 

--- a/Mittons.Fixtures/Docker/Gateways/NetworkGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/NetworkGateway.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Mittons.Fixtures.Extensions;
+using Mittons.Fixtures.Models;
 
 namespace Mittons.Fixtures.Docker.Gateways
 {
@@ -12,11 +11,9 @@ namespace Mittons.Fixtures.Docker.Gateways
     {
         private static TimeSpan _defaultTimeout = TimeSpan.FromSeconds(10);
 
-        public async Task CreateAsync(string networkName, IEnumerable<KeyValuePair<string, string>> options, CancellationToken cancellationToken)
+        public async Task CreateAsync(string networkName, IEnumerable<Option> options, CancellationToken cancellationToken)
         {
-            var formattedOptions = options.Select(x => $"{x.Key} \"{x.Value}\"");
-
-            using (var process = new DockerProcess($"network create {string.Join(" ", formattedOptions)} {networkName}"))
+            using (var process = new DockerProcess($"network create {options.ToCommandFormattedString()} {networkName}"))
             {
                 await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
             }

--- a/Mittons.Fixtures/Docker/Gateways/NetworkGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/NetworkGateway.cs
@@ -13,7 +13,7 @@ namespace Mittons.Fixtures.Docker.Gateways
 
         public async Task CreateAsync(string networkName, IEnumerable<Option> options, CancellationToken cancellationToken)
         {
-            using (var process = new DockerProcess($"network create {options.ToCommandFormattedString()} {networkName}"))
+            using (var process = new DockerProcess($"network create {options.ToExecutionParametersFormattedString()} {networkName}"))
             {
                 await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
             }

--- a/Mittons.Fixtures/Docker/Networks/Network.cs
+++ b/Mittons.Fixtures/Docker/Networks/Network.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Mittons.Fixtures.Docker.Attributes;
 using Mittons.Fixtures.Docker.Gateways;
+using Mittons.Fixtures.Models;
 
 namespace Mittons.Fixtures.Docker.Networks
 {
@@ -14,7 +15,7 @@ namespace Mittons.Fixtures.Docker.Networks
 
         private readonly string _name;
 
-        private readonly IEnumerable<KeyValuePair<string, string>> _options;
+        private readonly IEnumerable<Option> _options;
 
         private readonly bool _teardownOnComplete;
 

--- a/Mittons.Fixtures/Extensions/OptionExtensions.cs
+++ b/Mittons.Fixtures/Extensions/OptionExtensions.cs
@@ -15,7 +15,7 @@ namespace Mittons.Fixtures.Extensions
         /// </summary>
         /// <param name="option"></param>
         /// <returns>The option as a string formatted for use in a <c>docker</c> command.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the option, or its properties, are <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the option, or its name property is <c>null</c>.</exception>
         public static string ToExecutionParameterFormattedString(this Option option)
         {
             if(option is null)
@@ -28,12 +28,7 @@ namespace Mittons.Fixtures.Extensions
                 throw new ArgumentNullException(nameof(option.Name));
             }
 
-            if(option.Value is null)
-            {
-                throw new ArgumentNullException(nameof(option.Value));
-            }
-
-            return $"{option.Name} \"{option.Value}\"";
+            return string.IsNullOrWhiteSpace(option.Value) ? option.Name : $"{option.Name} \"{option.Value}\"";
         }
 
         /// <summary>

--- a/Mittons.Fixtures/Extensions/OptionExtensions.cs
+++ b/Mittons.Fixtures/Extensions/OptionExtensions.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mittons.Fixtures.Models;
+
+namespace Mittons.Fixtures.Extensions
+{
+    /// <summary>
+    /// Extensions methods for <see cref="Option"/>.
+    /// </summary>
+    public static class OptionExtensions
+    {
+        /// <summary>
+        /// Gets the option as a string formatted for use in a docker command.
+        /// </summary>
+        /// <param name="option"></param>
+        /// <returns>The option as a string formatted for use in a docker command.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the option, or its properties, are <c>null</c>.</exception>
+        public static string ToCommandFormattedString(this Option option)
+        {
+            if(option == null)
+            {
+                throw new ArgumentNullException(nameof(option));
+            }
+
+            if(option.Name == null)
+            {
+                throw new ArgumentNullException(nameof(option.Name));
+            }
+
+            if(option.Value == null)
+            {
+                throw new ArgumentNullException(nameof(option.Value));
+            }
+
+            return $"{option.Name} \"{option.Value}\"";
+        }
+
+        /// <summary>
+        /// Gets the collection of options as a string formatted for use in a docker command.
+        /// </summary>
+        /// <param name="options"></param>
+        /// <returns>The options as a string formatted for use in a docker command.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the options, any option, or their properties, are <c>null</c>.</exception>
+        public static string ToCommandFormattedString(this IEnumerable<Option> options)
+        {
+            if(options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            var formattedOptions = options.Select(option => option.ToCommandFormattedString())
+                .ToList();
+
+            return formattedOptions.Any() ? string.Join(" ", formattedOptions) : string.Empty;
+        }
+    }
+}

--- a/Mittons.Fixtures/Extensions/OptionExtensions.cs
+++ b/Mittons.Fixtures/Extensions/OptionExtensions.cs
@@ -11,24 +11,24 @@ namespace Mittons.Fixtures.Extensions
     public static class OptionExtensions
     {
         /// <summary>
-        /// Gets the option as a string formatted for use in a docker command.
+        /// Gets the option as a string formatted for use as an execution parameter in a <c>docker</c> command.
         /// </summary>
         /// <param name="option"></param>
-        /// <returns>The option as a string formatted for use in a docker command.</returns>
+        /// <returns>The option as a string formatted for use in a <c>docker</c> command.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the option, or its properties, are <c>null</c>.</exception>
-        public static string ToCommandFormattedString(this Option option)
+        public static string ToExecutionParameterFormattedString(this Option option)
         {
-            if(option == null)
+            if(option is null)
             {
                 throw new ArgumentNullException(nameof(option));
             }
 
-            if(option.Name == null)
+            if(option.Name is null)
             {
                 throw new ArgumentNullException(nameof(option.Name));
             }
 
-            if(option.Value == null)
+            if(option.Value is null)
             {
                 throw new ArgumentNullException(nameof(option.Value));
             }
@@ -37,19 +37,19 @@ namespace Mittons.Fixtures.Extensions
         }
 
         /// <summary>
-        /// Gets the collection of options as a string formatted for use in a docker command.
+        /// Gets the collection of options as a string formatted for use as execution parameters in a <c>docker</c> command.
         /// </summary>
         /// <param name="options"></param>
-        /// <returns>The options as a string formatted for use in a docker command.</returns>
+        /// <returns>The options as a string formatted for use in a <c>docker</c> command.</returns>
         /// <exception cref="ArgumentNullException">Thrown when the options, any option, or their properties, are <c>null</c>.</exception>
-        public static string ToCommandFormattedString(this IEnumerable<Option> options)
+        public static string ToExecutionParametersFormattedString(this IEnumerable<Option> options)
         {
-            if(options == null)
+            if(options is null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
 
-            var formattedOptions = options.Select(option => option.ToCommandFormattedString())
+            var formattedOptions = options.Select(option => option.ToExecutionParameterFormattedString())
                 .ToList();
 
             return formattedOptions.Any() ? string.Join(" ", formattedOptions) : string.Empty;

--- a/Mittons.Fixtures/Models/Option.cs
+++ b/Mittons.Fixtures/Models/Option.cs
@@ -1,0 +1,18 @@
+﻿namespace Mittons.Fixtures.Models
+{
+    /// <summary>
+    /// A docker option used to further configure a command.
+    /// </summary>
+    public class Option
+    {
+        /// <summary>
+        /// The name of the option.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The value for the option.
+        /// </summary>
+        public string Value { get; set; }
+    }
+}

--- a/Mittons.Fixtures/Models/Option.cs
+++ b/Mittons.Fixtures/Models/Option.cs
@@ -13,6 +13,10 @@
         /// <summary>
         /// The value for the option.
         /// </summary>
-        public string Value { get; set; }
+        /// <remarks>
+        /// Set as a direct value with no quotations.  
+        /// Set to an empty string if there is no value to accompany the option name.
+        /// </remarks>
+        public string Value { get; set; } = string.Empty;
     }
 }

--- a/Mittons.Fixtures/Models/Option.cs
+++ b/Mittons.Fixtures/Models/Option.cs
@@ -15,8 +15,8 @@
         /// </summary>
         /// <remarks>
         /// Set as a direct value with no quotations.  
-        /// Set to an empty string if there is no value to accompany the option name.
+        /// Set to <c>null</c>, <c>empty string</c>, or <c>white-space</c> if there is no value to accompany the option name.
         /// </remarks>
-        public string Value { get; set; } = string.Empty;
+        public string Value { get; set; }
     }
 }


### PR DESCRIPTION
- The new Option type has Name and Value for the docker command configuration options.
- Providing OptionExtensions (with unit tests) with methods for formatting the option(s) as docker command friendly strings.
- Minor removal of usused namespace includes.