### PR TITLE
Optimize tests

### DIFF
--- a/Mittons.Fixtures.Example/Fixtures/ReportingEnvironmentFixture.cs
+++ b/Mittons.Fixtures.Example/Fixtures/ReportingEnvironmentFixture.cs
@@ -1,6 +1,10 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Mittons.Fixtures.Docker.Attributes;
 using Mittons.Fixtures.Docker.Containers;
 using Mittons.Fixtures.Docker.Fixtures;
+using Mittons.Fixtures.Extensions;
 
 namespace Mittons.Fixtures.Example.Fixtures;
 
@@ -9,4 +13,7 @@ public class ReportingEnvironmentFixture : DockerEnvironmentFixture, Xunit.IAsyn
     [SftpUserAccount("admin", "securepassword")]
     [SftpUserAccount("tswift", "hatersgonnahate")]
     public SftpContainer SftpContainer { get; set; }
+
+    public override Task InitializeAsync()
+        => base.InitializeAsync(new CancellationToken().CreateLinkedTimeoutToken(TimeSpan.FromMinutes(5)));
 }

--- a/Mittons.Fixtures.Example/Sftp/ConnectionTests.cs
+++ b/Mittons.Fixtures.Example/Sftp/ConnectionTests.cs
@@ -47,7 +47,7 @@ public class ConnectionSettingsTests : IClassFixture<ReportingEnvironmentFixture
         // Arrange
         var connectionSettings = _reportingEnvironment.SftpContainer.SftpConnectionSettings.Single(x => x.Key == "admin").Value;
 
-        await _reportingEnvironment.SftpContainer.CreateUserFileAsync(connectionSettings.Username, fileContents, filename, default, default, CancellationToken.None);
+        await _reportingEnvironment.SftpContainer.CreateUserFileAsync(connectionSettings.Username, fileContents, filename, default, default, new CancellationToken());
 
         var connectionInfo = new ConnectionInfo(
                 connectionSettings.Host,

--- a/Mittons.Fixtures.Tests.Integration/Docker/Gateways/ContainerGatewayTests.cs
+++ b/Mittons.Fixtures.Tests.Integration/Docker/Gateways/ContainerGatewayTests.cs
@@ -299,7 +299,7 @@ public class ContainerGatewayTests
             _containerIds.Add(containerId);
 
             // Act
-            var ipAddress = await containerGateway.GetDefaultNetworkIpAddressAsync(containerId, _cancellationToken);
+            var ipAddress = await containerGateway.GetDefaultNetworkIpAddressAsync(containerId, new CancellationToken());
 
             // Assert
             using var proc = new Process();

--- a/Mittons.Fixtures.Tests.Integration/Docker/Gateways/ContainerGatewayTests.cs
+++ b/Mittons.Fixtures.Tests.Integration/Docker/Gateways/ContainerGatewayTests.cs
@@ -299,7 +299,7 @@ public class ContainerGatewayTests
             _containerIds.Add(containerId);
 
             // Act
-            var ipAddress = await containerGateway.GetDefaultNetworkIpAddressAsync(containerId, new CancellationToken());
+            var ipAddress = await containerGateway.GetDefaultNetworkIpAddressAsync(containerId, _cancellationToken);
 
             // Assert
             using var proc = new Process();

--- a/Mittons.Fixtures.Tests.Integration/Docker/Gateways/ContainerGatewayTests.cs
+++ b/Mittons.Fixtures.Tests.Integration/Docker/Gateways/ContainerGatewayTests.cs
@@ -21,6 +21,16 @@ public class ContainerGatewayTests
     {
         private readonly List<string> _containerIds = new List<string>();
 
+        private readonly CancellationToken _cancellationToken;
+
+        public RunTests()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(TimeSpan.FromMinutes(1));
+
+            _cancellationToken = cancellationTokenSource.Token;
+        }
+
         public void Dispose()
         {
             foreach (var containerId in _containerIds)
@@ -60,7 +70,7 @@ public class ContainerGatewayTests
                             Value = "third=fourth"
                         }
                     },
-                    CancellationToken.None
+                    _cancellationToken
                 );
 
             _containerIds.Add(containerId);
@@ -92,7 +102,7 @@ public class ContainerGatewayTests
             var containerGateway = new ContainerGateway();
 
             // Act
-            var containers = images.Select(x => (Image: x, Task: containerGateway.RunAsync(x, string.Empty, Enumerable.Empty<Option>(), CancellationToken.None)));
+            var containers = images.Select(x => (Image: x, Task: containerGateway.RunAsync(x, string.Empty, Enumerable.Empty<Option>(), _cancellationToken)));
             await Task.WhenAll(containers.Select(x => x.Task));
 
             _containerIds.AddRange(containers.Select(x => x.Task.Result));
@@ -124,7 +134,7 @@ public class ContainerGatewayTests
             var containerGateway = new ContainerGateway();
 
             // Act
-            var containerId = await containerGateway.RunAsync("alpine:3.15", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("alpine:3.15", string.Empty, Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Assert
@@ -156,7 +166,7 @@ public class ContainerGatewayTests
             var containerGateway = new ContainerGateway();
 
             // Act
-            var containerId = await containerGateway.RunAsync("alpine:3.15", "/bin/bash", Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("alpine:3.15", "/bin/bash", Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Assert
@@ -186,6 +196,16 @@ public class ContainerGatewayTests
     {
         private readonly List<string> _containerIds = new List<string>();
 
+        private readonly CancellationToken _cancellationToken;
+
+        public RemoveTests()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(TimeSpan.FromMinutes(1));
+
+            _cancellationToken = cancellationTokenSource.Token;
+        }
+
         public void Dispose()
         {
             foreach (var containerId in _containerIds)
@@ -209,7 +229,7 @@ public class ContainerGatewayTests
 
             // Act
             // Assert
-            await containerGateway.RemoveAsync("cd898788786795df83dbf414bbcc9e6c6be9d4bc932e96a6542c03d033e1cc72", CancellationToken.None);
+            await containerGateway.RemoveAsync("cd898788786795df83dbf414bbcc9e6c6be9d4bc932e96a6542c03d033e1cc72", _cancellationToken);
         }
 
         [Fact]
@@ -218,11 +238,11 @@ public class ContainerGatewayTests
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("alpine:3.15", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("alpine:3.15", string.Empty, Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Act
-            await containerGateway.RemoveAsync(containerId, CancellationToken.None);
+            await containerGateway.RemoveAsync(containerId, _cancellationToken);
 
             // Assert
             using var proc = new Process();
@@ -243,6 +263,16 @@ public class ContainerGatewayTests
     public class GetDefaultNetworkIpAddressTests : IDisposable
     {
         private readonly List<string> _containerIds = new List<string>();
+
+        private readonly CancellationToken _cancellationToken;
+
+        public GetDefaultNetworkIpAddressTests()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(TimeSpan.FromMinutes(1));
+
+            _cancellationToken = cancellationTokenSource.Token;
+        }
 
         public void Dispose()
         {
@@ -265,11 +295,11 @@ public class ContainerGatewayTests
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Act
-            var ipAddress = await containerGateway.GetDefaultNetworkIpAddressAsync(containerId, CancellationToken.None);
+            var ipAddress = await containerGateway.GetDefaultNetworkIpAddressAsync(containerId, _cancellationToken);
 
             // Assert
             using var proc = new Process();
@@ -292,6 +322,16 @@ public class ContainerGatewayTests
         private readonly List<string> _containerIds = new List<string>();
 
         private readonly List<string> _filenames = new List<string>();
+
+        private readonly CancellationToken _cancellationToken;
+
+        public AddFile()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(TimeSpan.FromMinutes(1));
+
+            _cancellationToken = cancellationTokenSource.Token;
+        }
 
         public void Dispose()
         {
@@ -334,11 +374,11 @@ public class ContainerGatewayTests
 
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Act
-            var tasks = files.Select(x => containerGateway.AddFileAsync(containerId, x.TemporaryFilename, x.ContainerFilename, default(string), default(string), CancellationToken.None));
+            var tasks = files.Select(x => containerGateway.AddFileAsync(containerId, x.TemporaryFilename, x.ContainerFilename, default(string), default(string), _cancellationToken));
             await Task.WhenAll(tasks);
 
             // Assert
@@ -381,11 +421,11 @@ public class ContainerGatewayTests
 
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Act
-            var tasks = files.Select(x => containerGateway.AddFileAsync(containerId, x.TemporaryFilename, x.ContainerFilename, default(string), default(string), CancellationToken.None));
+            var tasks = files.Select(x => containerGateway.AddFileAsync(containerId, x.TemporaryFilename, x.ContainerFilename, default(string), default(string), _cancellationToken));
             await Task.WhenAll(tasks);
 
             // Assert
@@ -428,11 +468,11 @@ public class ContainerGatewayTests
 
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Act
-            var tasks = files.Select(x => containerGateway.AddFileAsync(containerId, x.TemporaryFilename, x.ContainerFilename, default(string), x.Permissions, CancellationToken.None));
+            var tasks = files.Select(x => containerGateway.AddFileAsync(containerId, x.TemporaryFilename, x.ContainerFilename, default(string), x.Permissions, _cancellationToken));
             await Task.WhenAll(tasks);
 
             // Assert
@@ -475,11 +515,11 @@ public class ContainerGatewayTests
 
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Act
-            var tasks = files.Select(x => containerGateway.AddFileAsync(containerId, x.TemporaryFilename, x.ContainerFilename, x.Owner, default(string), CancellationToken.None));
+            var tasks = files.Select(x => containerGateway.AddFileAsync(containerId, x.TemporaryFilename, x.ContainerFilename, x.Owner, default(string), _cancellationToken));
             await Task.WhenAll(tasks);
 
             // Assert
@@ -508,6 +548,16 @@ public class ContainerGatewayTests
         private readonly List<string> _containerIds = new List<string>();
 
         private readonly List<string> _filenames = new List<string>();
+
+        private readonly CancellationToken _cancellationToken;
+
+        public RemoveFile()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(TimeSpan.FromMinutes(1));
+
+            _cancellationToken = cancellationTokenSource.Token;
+        }
 
         public void Dispose()
         {
@@ -551,14 +601,14 @@ public class ContainerGatewayTests
 
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest tester:tester", Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
-            var addTasks = files.Select(x => containerGateway.AddFileAsync(containerId, x.TemporaryFilename, x.ContainerFilename, default(string), default(string), CancellationToken.None));
+            var addTasks = files.Select(x => containerGateway.AddFileAsync(containerId, x.TemporaryFilename, x.ContainerFilename, default(string), default(string), _cancellationToken));
             await Task.WhenAll(addTasks);
 
             // Act
-            var removeTasks = files.Select(x => containerGateway.RemoveFileAsync(containerId, x.ContainerFilename, CancellationToken.None));
+            var removeTasks = files.Select(x => containerGateway.RemoveFileAsync(containerId, x.ContainerFilename, _cancellationToken));
             await Task.WhenAll(removeTasks);
 
             // Assert
@@ -586,6 +636,16 @@ public class ContainerGatewayTests
     {
         private readonly List<string> _containerIds = new List<string>();
 
+        private readonly CancellationToken _cancellationToken;
+
+        public ExecuteCommandTests()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(TimeSpan.FromMinutes(1));
+
+            _cancellationToken = cancellationTokenSource.Token;
+        }
+
         public void Dispose()
         {
             foreach (var containerId in _containerIds)
@@ -607,7 +667,7 @@ public class ContainerGatewayTests
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             for (var i = 0; i < 10; ++i)
@@ -646,6 +706,16 @@ public class ContainerGatewayTests
     {
         private readonly List<string> _containerIds = new List<string>();
 
+        private readonly CancellationToken _cancellationToken;
+
+        public GetHostPortMapping()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(TimeSpan.FromMinutes(1));
+
+            _cancellationToken = cancellationTokenSource.Token;
+        }
+
         public void Dispose()
         {
             foreach (var containerId in _containerIds)
@@ -662,22 +732,22 @@ public class ContainerGatewayTests
         }
 
         [Fact]
-        public async Task GetHostPortMapping_WhenCalledForSftp_ExpectHostPortToBeReturnedForContainerPort22()
+        public async Task GetHostPortMapping_WhenCalledForExposedPorts_ExpectHostPortToBeReturned()
         {
             // Arrange
             var containerGateway = new ContainerGateway();
 
             var containers = new (Task<string> Task, string Scheme, int Port)[]
             {
-                (containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None), "tcp", 22),
-                (containerGateway.RunAsync("redis:alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None), "tcp", 6379)
+                (containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), _cancellationToken), "tcp", 22),
+                (containerGateway.RunAsync("redis:alpine", string.Empty, Enumerable.Empty<Option>(), _cancellationToken), "tcp", 6379)
             };
             await Task.WhenAll(containers.Select(x => x.Task));
 
             _containerIds.AddRange(containers.Select(x => x.Task.Result));
 
             // Act
-            var portMappings = containers.Select(x => (Task: containerGateway.GetHostPortMappingAsync(x.Task.Result, x.Scheme, x.Port, CancellationToken.None), ContainerId: x.Task.Result, Scheme: x.Scheme, Port: x.Port));
+            var portMappings = containers.Select(x => (Task: containerGateway.GetHostPortMappingAsync(x.Task.Result, x.Scheme, x.Port, _cancellationToken), ContainerId: x.Task.Result, Scheme: x.Scheme, Port: x.Port));
             await Task.WhenAll(portMappings.Select(x => x.Task));
 
             // Assert
@@ -707,6 +777,16 @@ public class ContainerGatewayTests
 
         private readonly List<string> _filenames = new List<string>();
 
+        private readonly CancellationToken _cancellationToken;
+
+        public GetHealthStatusAsync()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.CancelAfter(TimeSpan.FromMinutes(1));
+
+            _cancellationToken = cancellationTokenSource.Token;
+        }
+
         public void Dispose()
         {
             foreach (var containerId in _containerIds)
@@ -728,11 +808,11 @@ public class ContainerGatewayTests
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("redis:alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("redis:alpine", string.Empty, Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Act
-            var healthStatus = await containerGateway.GetHealthStatusAsync(containerId, CancellationToken.None);
+            var healthStatus = await containerGateway.GetHealthStatusAsync(containerId, _cancellationToken);
 
             // Assert
             Assert.Equal(HealthStatus.Running, healthStatus);
@@ -744,12 +824,12 @@ public class ContainerGatewayTests
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("--health-cmd=\"echo hello\" --health-interval=1s redis:alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("--health-cmd=\"echo hello\" --health-interval=1s redis:alpine", string.Empty, Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Act
             await Task.Delay(TimeSpan.FromSeconds(5));
-            var healthStatus = await containerGateway.GetHealthStatusAsync(containerId, CancellationToken.None);
+            var healthStatus = await containerGateway.GetHealthStatusAsync(containerId, _cancellationToken);
 
             // Assert
             Assert.Equal(HealthStatus.Healthy, healthStatus);
@@ -761,12 +841,12 @@ public class ContainerGatewayTests
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Act
             await Task.Delay(TimeSpan.FromSeconds(2));
-            var healthStatus = await containerGateway.GetHealthStatusAsync(containerId, CancellationToken.None);
+            var healthStatus = await containerGateway.GetHealthStatusAsync(containerId, _cancellationToken);
 
             // Assert
             Assert.Equal(HealthStatus.Unhealthy, healthStatus);
@@ -778,11 +858,11 @@ public class ContainerGatewayTests
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("--health-cmd=\"exit 1\" --health-interval=1s --health-retries=1 --health-start-period=1s redis:alpine", string.Empty, Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             // Act
-            var healthStatus = await containerGateway.GetHealthStatusAsync(containerId, CancellationToken.None);
+            var healthStatus = await containerGateway.GetHealthStatusAsync(containerId, _cancellationToken);
 
             // Assert
             Assert.Equal(HealthStatus.Unknown, healthStatus);
@@ -794,7 +874,7 @@ public class ContainerGatewayTests
             // Arrange
             var containerGateway = new ContainerGateway();
 
-            var containerId = await containerGateway.RunAsync("alpine", string.Empty, Enumerable.Empty<Option>(), CancellationToken.None);
+            var containerId = await containerGateway.RunAsync("alpine", string.Empty, Enumerable.Empty<Option>(), _cancellationToken);
             _containerIds.Add(containerId);
 
             for (var i = 0; i < 10; ++i)
@@ -820,7 +900,7 @@ public class ContainerGatewayTests
             }
 
             // Act
-            var healthStatus = await containerGateway.GetHealthStatusAsync(containerId, CancellationToken.None);
+            var healthStatus = await containerGateway.GetHealthStatusAsync(containerId, _cancellationToken);
 
             // Assert
             Assert.Equal(HealthStatus.Unknown, healthStatus);

--- a/Mittons.Fixtures.Tests.Integration/Docker/Gateways/NetworkGatewayTests.cs
+++ b/Mittons.Fixtures.Tests.Integration/Docker/Gateways/NetworkGatewayTests.cs
@@ -18,6 +18,16 @@ public class NetworkGatewayTests : IDisposable
 
     private readonly List<string> _containerIds = new List<string>();
 
+    private readonly CancellationToken _cancellationToken;
+
+    public NetworkGatewayTests()
+    {
+        var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.CancelAfter(TimeSpan.FromMinutes(1));
+
+        _cancellationToken = cancellationTokenSource.Token;
+    }
+
     public void Dispose()
     {
         foreach (var containerId in _containerIds)
@@ -57,7 +67,7 @@ public class NetworkGatewayTests : IDisposable
         _networkNames.Add(uniqueName);
 
         // Act
-        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<Option>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
+        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<Option>(), _cancellationToken.CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
 
         // Assert
         using var proc = new Process();
@@ -100,7 +110,7 @@ public class NetworkGatewayTests : IDisposable
         _networkNames.Add(uniqueName);
 
         // Act
-        await networkGateway.CreateAsync(uniqueName, expectedOptions, (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
+        await networkGateway.CreateAsync(uniqueName, expectedOptions, _cancellationToken.CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
 
         // Assert
         using var proc = new Process();
@@ -131,10 +141,10 @@ public class NetworkGatewayTests : IDisposable
 
         _networkNames.Add(uniqueName);
 
-        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<Option>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
+        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<Option>(), _cancellationToken.CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
 
         // Act
-        await networkGateway.RemoveAsync(uniqueName, CancellationToken.None);
+        await networkGateway.RemoveAsync(uniqueName, _cancellationToken);
 
         // Assert
         using var proc = new Process();
@@ -161,15 +171,15 @@ public class NetworkGatewayTests : IDisposable
         var networkGateway = new NetworkGateway();
         var containerGateway = new ContainerGateway();
 
-        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), CancellationToken.None);
+        var containerId = await containerGateway.RunAsync("atmoz/sftp:alpine", "guest:guest", Enumerable.Empty<Option>(), _cancellationToken);
         _containerIds.Add(containerId);
 
         _networkNames.Add(uniqueName);
 
-        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<Option>(), (new CancellationToken()).CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
+        await networkGateway.CreateAsync(uniqueName, Enumerable.Empty<Option>(), _cancellationToken.CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)));
 
         // Act
-        await networkGateway.ConnectAsync(uniqueName, containerId, "test.example.com", CancellationToken.None);
+        await networkGateway.ConnectAsync(uniqueName, containerId, "test.example.com", _cancellationToken);
 
         // Assert
         using var proc = new Process();

--- a/Mittons.Fixtures.Tests.Integration/Docker/Gateways/NetworkGatewayTests.cs
+++ b/Mittons.Fixtures.Tests.Integration/Docker/Gateways/NetworkGatewayTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Mittons.Fixtures.Tests.Integration.Docker.Gateways;
 
-public class NetworkGatewayTests
+public class NetworkGatewayTests : IDisposable
 {
     private readonly List<string> _networkNames = new List<string>();
 

--- a/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Mittons.Fixtures.Tests.Unit.Docker.Containers;
 
-public class ContainerTests : BaseContainerTests
+public class ContainerTests
 {
     public class InitializeTests
     {
@@ -200,9 +200,12 @@ public class ContainerTests : BaseContainerTests
                 var container = new Container(containerGatewayMock.Object, networkGatewayMock.Object, Guid.Empty, new Attribute[] { new ImageAttribute(string.Empty), new CommandAttribute(string.Empty), new RunAttribute() });
                 _containers.Add(container);
 
+                var cancellationTokenSource = new CancellationTokenSource();
+                cancellationTokenSource.CancelAfter(TimeSpan.FromMilliseconds(100));
+
                 // Act
                 // Assert
-                await Assert.ThrowsAsync<OperationCanceledException>(() => container.InitializeAsync(CancellationToken.None));
+                await Assert.ThrowsAsync<OperationCanceledException>(() => container.InitializeAsync(cancellationTokenSource.Token));
             }
 
             [Fact]

--- a/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
@@ -201,7 +201,7 @@ public class ContainerTests
                 _containers.Add(container);
 
                 var cancellationTokenSource = new CancellationTokenSource();
-                cancellationTokenSource.CancelAfter(TimeSpan.FromMilliseconds(100));
+                cancellationTokenSource.CancelAfter(TimeSpan.FromMilliseconds(110));
 
                 // Act
                 // Assert

--- a/Mittons.Fixtures.Tests.Unit/Docker/Fixtures/DockerEnvironmentFixtureTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Fixtures/DockerEnvironmentFixtureTests.cs
@@ -12,7 +12,7 @@ using Mittons.Fixtures.Models;
 using Moq;
 using Xunit;
 
-namespace Mittons.Fixtures.Tests.Unit.Docker.Environments;
+namespace Mittons.Fixtures.Tests.Unit.Docker.Fixtures;
 
 public class DockerEnvironmentFixtureTests
 {

--- a/Mittons.Fixtures/Docker/Containers/Container.cs
+++ b/Mittons.Fixtures/Docker/Containers/Container.cs
@@ -59,14 +59,14 @@ namespace Mittons.Fixtures.Docker.Containers
         /// </remarks>
         public virtual async Task InitializeAsync(CancellationToken cancellationToken)
         {
-            Id = await _containerGateway.RunAsync(_imageName, _command, _options, cancellationToken);
-            IpAddress = await _containerGateway.GetDefaultNetworkIpAddressAsync(Id, cancellationToken);
+            Id = await _containerGateway.RunAsync(_imageName, _command, _options, cancellationToken).ConfigureAwait(false);
+            IpAddress = await _containerGateway.GetDefaultNetworkIpAddressAsync(Id, cancellationToken).ConfigureAwait(false);
 
-            await EnsureHealthyAsync(cancellationToken);
+            await EnsureHealthyAsync(cancellationToken).ConfigureAwait(false);
 
             foreach (var networkAlias in _networks)
             {
-                await _networkGateway.ConnectAsync($"{networkAlias.NetworkName}-{_instanceId}", Id, networkAlias.Alias, cancellationToken);
+                await _networkGateway.ConnectAsync($"{networkAlias.NetworkName}-{_instanceId}", Id, networkAlias.Alias, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -83,7 +83,7 @@ namespace Mittons.Fixtures.Docker.Containers
 
             File.WriteAllText(temporaryFilename, fileContents);
 
-            await AddFileAsync(temporaryFilename, containerFilename, owner, permissions, cancellationToken);
+            await AddFileAsync(temporaryFilename, containerFilename, owner, permissions, cancellationToken).ConfigureAwait(false);
 
             File.Delete(temporaryFilename);
         }
@@ -97,7 +97,7 @@ namespace Mittons.Fixtures.Docker.Containers
                 fileContents.CopyTo(fileStream);
             }
 
-            await AddFileAsync(temporaryFilename, containerFilename, owner, permissions, cancellationToken);
+            await AddFileAsync(temporaryFilename, containerFilename, owner, permissions, cancellationToken).ConfigureAwait(false);
 
             File.Delete(temporaryFilename);
         }
@@ -114,14 +114,14 @@ namespace Mittons.Fixtures.Docker.Containers
 
             while (true)
             {
-                var healthStatus = await _containerGateway.GetHealthStatusAsync(Id, timeoutToken);
+                var healthStatus = await _containerGateway.GetHealthStatusAsync(Id, timeoutToken).ConfigureAwait(false);
 
                 if ((healthStatus == HealthStatus.Running) || (healthStatus == HealthStatus.Healthy))
                 {
                     break;
                 }
 
-                await Task.Delay(TimeSpan.FromMilliseconds(50));
+                await Task.Delay(TimeSpan.FromMilliseconds(50)).ConfigureAwait(false);
 
                 timeoutToken.ThrowIfCancellationRequested();
             }

--- a/Mittons.Fixtures/Docker/Containers/Container.cs
+++ b/Mittons.Fixtures/Docker/Containers/Container.cs
@@ -75,7 +75,7 @@ namespace Mittons.Fixtures.Docker.Containers
         /// This must be invoked when an instance of <see cref="Container"/> is no longer used.
         /// </remarks>
         public virtual Task DisposeAsync()
-            => _teardownOnComplete ? _containerGateway.RemoveAsync(Id, CancellationToken.None) : Task.CompletedTask;
+            => _teardownOnComplete ? _containerGateway.RemoveAsync(Id, new CancellationToken()) : Task.CompletedTask;
 
         public async Task CreateFileAsync(string fileContents, string containerFilename, string owner, string permissions, CancellationToken cancellationToken)
         {

--- a/Mittons.Fixtures/Docker/Containers/SftpContainer.cs
+++ b/Mittons.Fixtures/Docker/Containers/SftpContainer.cs
@@ -29,19 +29,19 @@ namespace Mittons.Fixtures.Docker.Containers
 
         public override async Task InitializeAsync(CancellationToken cancellationToken)
         {
-            await base.InitializeAsync(cancellationToken);
+            await base.InitializeAsync(cancellationToken).ConfigureAwait(false);
 
             var host = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "localhost" : IpAddress.ToString();
-            var port = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? await _containerGateway.GetHostPortMappingAsync(Id, "tcp", 22, cancellationToken) : 22;
+            var port = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? await _containerGateway.GetHostPortMappingAsync(Id, "tcp", 22, cancellationToken).ConfigureAwait(false) : 22;
             var rsaFingerprint = new Fingerprint
             {
-                Md5 = await GetFingerprintAsync(_containerGateway, "rsa", "md5", cancellationToken),
-                Sha256 = await GetFingerprintAsync(_containerGateway, "rsa", "sha256", cancellationToken)
+                Md5 = await GetFingerprintAsync(_containerGateway, "rsa", "md5", cancellationToken).ConfigureAwait(false),
+                Sha256 = await GetFingerprintAsync(_containerGateway, "rsa", "sha256", cancellationToken).ConfigureAwait(false)
             };
             var ed25519Fingerprint = new Fingerprint
             {
-                Md5 = await GetFingerprintAsync(_containerGateway, "ed25519", "md5", cancellationToken),
-                Sha256 = await GetFingerprintAsync(_containerGateway, "ed25519", "sha256", cancellationToken)
+                Md5 = await GetFingerprintAsync(_containerGateway, "ed25519", "md5", cancellationToken).ConfigureAwait(false),
+                Sha256 = await GetFingerprintAsync(_containerGateway, "ed25519", "sha256", cancellationToken).ConfigureAwait(false)
             };
 
             SftpConnectionSettings = _accounts.Select(
@@ -75,7 +75,7 @@ namespace Mittons.Fixtures.Docker.Containers
 
         private async Task<string> GetFingerprintAsync(IContainerGateway containerGateway, string algorithm, string hash, CancellationToken cancellationToken)
         {
-            var execResults = (await containerGateway.ExecuteCommandAsync(Id, $"ssh-keygen -l -E {hash} -f /etc/ssh/ssh_host_{algorithm}_key.pub", cancellationToken.CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5)))).ToArray();
+            var execResults = (await containerGateway.ExecuteCommandAsync(Id, $"ssh-keygen -l -E {hash} -f /etc/ssh/ssh_host_{algorithm}_key.pub", cancellationToken.CreateLinkedTimeoutToken(TimeSpan.FromSeconds(5))).ConfigureAwait(false)).ToArray();
 
             if (execResults.Length != 1)
             {

--- a/Mittons.Fixtures/Docker/Fixtures/DockerEnvironmentFixture.cs
+++ b/Mittons.Fixtures/Docker/Fixtures/DockerEnvironmentFixture.cs
@@ -61,7 +61,7 @@ namespace Mittons.Fixtures.Docker.Fixtures
         /// <remarks>
         /// This must be invoked after an instance of <see cref="DockerEnvironmentFixture"/> is created, before it is used.
         /// </remarks>
-        public Task InitializeAsync()
+        public virtual Task InitializeAsync()
             => InitializeAsync(new CancellationToken());
 
         /// <inheritdoc/>

--- a/Mittons.Fixtures/Docker/Fixtures/DockerEnvironmentFixture.cs
+++ b/Mittons.Fixtures/Docker/Fixtures/DockerEnvironmentFixture.cs
@@ -70,9 +70,9 @@ namespace Mittons.Fixtures.Docker.Fixtures
         /// </remarks>
         public async Task InitializeAsync(CancellationToken cancellationToken)
         {
-            await Task.WhenAll(_networks.Select(x => x.InitializeAsync(cancellationToken)));
+            await Task.WhenAll(_networks.Select(x => x.InitializeAsync(cancellationToken))).ConfigureAwait(false);
 
-            await Task.WhenAll(_containers.Select(x => x.InitializeAsync(cancellationToken)));
+            await Task.WhenAll(_containers.Select(x => x.InitializeAsync(cancellationToken))).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -81,9 +81,9 @@ namespace Mittons.Fixtures.Docker.Fixtures
         /// </remarks>
         public async Task DisposeAsync()
         {
-            await Task.WhenAll(_containers.Select(x => x.DisposeAsync()));
+            await Task.WhenAll(_containers.Select(x => x.DisposeAsync())).ConfigureAwait(false);
 
-            await Task.WhenAll(_networks.Select(x => x.DisposeAsync()));
+            await Task.WhenAll(_networks.Select(x => x.DisposeAsync())).ConfigureAwait(false);
         }
     }
 }

--- a/Mittons.Fixtures/Docker/Fixtures/DockerEnvironmentFixture.cs
+++ b/Mittons.Fixtures/Docker/Fixtures/DockerEnvironmentFixture.cs
@@ -62,7 +62,7 @@ namespace Mittons.Fixtures.Docker.Fixtures
         /// This must be invoked after an instance of <see cref="DockerEnvironmentFixture"/> is created, before it is used.
         /// </remarks>
         public Task InitializeAsync()
-            => InitializeAsync(CancellationToken.None);
+            => InitializeAsync(new CancellationToken());
 
         /// <inheritdoc/>
         /// <remarks>

--- a/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
@@ -17,7 +17,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"run -P -d {options.ToExecutionParametersFormattedString()} {imageName} {command}"))
             {
-                await process.RunProcessAsync(new CancellationToken());
+                await process.RunProcessAsync(cancellationToken);
 
                 var containerId = default(string);
 

--- a/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
@@ -11,8 +11,6 @@ namespace Mittons.Fixtures.Docker.Gateways
 {
     public class ContainerGateway : IContainerGateway
     {
-        private static TimeSpan _defaultTimeout = TimeSpan.FromSeconds(10);
-
         public async Task<string> RunAsync(string imageName, string command, IEnumerable<Option> options, CancellationToken cancellationToken)
         {
             using (var process = new DockerProcess($"run -P -d {options.ToExecutionParametersFormattedString()} {imageName} {command}"))
@@ -56,19 +54,19 @@ namespace Mittons.Fixtures.Docker.Gateways
 
             using (var process = new DockerProcess($"exec {containerId} mkdir -p \"{directory}\" >/dev/null 2>&1"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
             }
 
             using (var process = new DockerProcess($"cp \"{hostFilename}\" \"{containerId}:{containerFilename}\""))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
             }
 
             if (!string.IsNullOrWhiteSpace(owner))
             {
                 using (var process = new DockerProcess($"exec {containerId} chown {owner} \"{containerFilename}\""))
                 {
-                    await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
+                    await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -76,7 +74,7 @@ namespace Mittons.Fixtures.Docker.Gateways
             {
                 using (var process = new DockerProcess($"exec {containerId} chmod {permissions} \"{containerFilename}\""))
                 {
-                    await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
+                    await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
         }
@@ -85,7 +83,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"exec {containerId} rm \"{containerFilename}\""))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -111,7 +109,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"port {containerId} {containerPort}/{protocol}"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
 
                 int.TryParse((await process.StandardOutput.ReadLineAsync().ConfigureAwait(false)).Split(':').Last(), out var port);
 
@@ -123,7 +121,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"inspect {containerId} -f \"{{{{if .State.Health}}}}{{{{.State.Health.Status}}}}{{{{else}}}}{{{{.State.Status}}}}{{{{end}}}}\""))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
 
                 switch (await process.StandardOutput.ReadLineAsync().ConfigureAwait(false))
                 {

--- a/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
@@ -99,7 +99,7 @@ namespace Mittons.Fixtures.Docker.Gateways
 
                 while (!process.StandardOutput.EndOfStream)
                 {
-                    var line = await process.StandardOutput.ReadLineAsync();
+                    var line = await process.StandardOutput.ReadLineAsync().ConfigureAwait(false);
                     lines.Add(line);
                 }
 
@@ -113,7 +113,7 @@ namespace Mittons.Fixtures.Docker.Gateways
             {
                 await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
 
-                int.TryParse((await process.StandardOutput.ReadLineAsync()).Split(':').Last(), out var port);
+                int.TryParse((await process.StandardOutput.ReadLineAsync().ConfigureAwait(false)).Split(':').Last(), out var port);
 
                 return port;
             }

--- a/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
@@ -17,7 +17,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"run -P -d {options.ToExecutionParametersFormattedString()} {imageName} {command}"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                await process.RunProcessAsync(new CancellationToken());
 
                 var containerId = default(string);
 

--- a/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
@@ -17,7 +17,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"run -P -d {options.ToExecutionParametersFormattedString()} {imageName} {command}"))
             {
-                await process.RunProcessAsync(cancellationToken);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
 
                 var containerId = default(string);
 
@@ -34,7 +34,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"rm --force {containerId}"))
             {
-                await process.RunProcessAsync(cancellationToken);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -42,7 +42,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"inspect {containerId} --format \"{{{{range .NetworkSettings.Networks}}}}{{{{printf \\\"%s\\n\\\" .IPAddress}}}}{{{{end}}}}\""))
             {
-                await process.RunProcessAsync(cancellationToken);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
 
                 IPAddress.TryParse(process.StandardOutput.ReadLine(), out var expectedIpAddress);
 
@@ -56,19 +56,19 @@ namespace Mittons.Fixtures.Docker.Gateways
 
             using (var process = new DockerProcess($"exec {containerId} mkdir -p \"{directory}\" >/dev/null 2>&1"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
             }
 
             using (var process = new DockerProcess($"cp \"{hostFilename}\" \"{containerId}:{containerFilename}\""))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
             }
 
             if (!string.IsNullOrWhiteSpace(owner))
             {
                 using (var process = new DockerProcess($"exec {containerId} chown {owner} \"{containerFilename}\""))
                 {
-                    await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                    await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
                 }
             }
 
@@ -76,7 +76,7 @@ namespace Mittons.Fixtures.Docker.Gateways
             {
                 using (var process = new DockerProcess($"exec {containerId} chmod {permissions} \"{containerFilename}\""))
                 {
-                    await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                    await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
                 }
             }
         }
@@ -85,7 +85,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"exec {containerId} rm \"{containerFilename}\""))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
             }
         }
 
@@ -93,7 +93,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"exec {containerId} {command}"))
             {
-                await process.RunProcessAsync(cancellationToken);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
 
                 var lines = new List<string>();
 
@@ -111,7 +111,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"port {containerId} {containerPort}/{protocol}"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
 
                 int.TryParse((await process.StandardOutput.ReadLineAsync()).Split(':').Last(), out var port);
 
@@ -123,9 +123,9 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"inspect {containerId} -f \"{{{{if .State.Health}}}}{{{{.State.Health.Status}}}}{{{{else}}}}{{{{.State.Status}}}}{{{{end}}}}\""))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
 
-                switch (await process.StandardOutput.ReadLineAsync())
+                switch (await process.StandardOutput.ReadLineAsync().ConfigureAwait(false))
                 {
                     case "running":
                         return HealthStatus.Running;

--- a/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
@@ -42,7 +42,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"inspect {containerId} --format \"{{{{range .NetworkSettings.Networks}}}}{{{{printf \\\"%s\\n\\\" .IPAddress}}}}{{{{end}}}}\""))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                await process.RunProcessAsync(cancellationToken);
 
                 IPAddress.TryParse(process.StandardOutput.ReadLine(), out var expectedIpAddress);
 

--- a/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/ContainerGateway.cs
@@ -34,7 +34,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"rm --force {containerId}"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                await process.RunProcessAsync(cancellationToken);
             }
         }
 

--- a/Mittons.Fixtures/Docker/Gateways/NetworkGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/NetworkGateway.cs
@@ -15,7 +15,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"network create {options.ToExecutionParametersFormattedString()} {networkName}"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
             }
         }
 
@@ -23,7 +23,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"network rm {networkName}"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
             }
         }
 
@@ -31,7 +31,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"network connect --alias {alias} {networkName} {containerId}"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout));
+                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
             }
         }
     }

--- a/Mittons.Fixtures/Docker/Gateways/NetworkGateway.cs
+++ b/Mittons.Fixtures/Docker/Gateways/NetworkGateway.cs
@@ -9,13 +9,11 @@ namespace Mittons.Fixtures.Docker.Gateways
 {
     public class NetworkGateway : INetworkGateway
     {
-        private static TimeSpan _defaultTimeout = TimeSpan.FromSeconds(10);
-
         public async Task CreateAsync(string networkName, IEnumerable<Option> options, CancellationToken cancellationToken)
         {
             using (var process = new DockerProcess($"network create {options.ToExecutionParametersFormattedString()} {networkName}"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -23,7 +21,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"network rm {networkName}"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -31,7 +29,7 @@ namespace Mittons.Fixtures.Docker.Gateways
         {
             using (var process = new DockerProcess($"network connect --alias {alias} {networkName} {containerId}"))
             {
-                await process.RunProcessAsync(cancellationToken.CreateLinkedTimeoutToken(_defaultTimeout)).ConfigureAwait(false);
+                await process.RunProcessAsync(cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/Mittons.Fixtures/Docker/Networks/Network.cs
+++ b/Mittons.Fixtures/Docker/Networks/Network.cs
@@ -35,7 +35,7 @@ namespace Mittons.Fixtures.Docker.Networks
         /// This must be invoked when an instance of <see cref="Network"/> is no longer used.
         /// </remarks>
         public Task DisposeAsync()
-            => _teardownOnComplete ? _networkGateway.RemoveAsync(_name, CancellationToken.None) : Task.CompletedTask;
+            => _teardownOnComplete ? _networkGateway.RemoveAsync(_name, new CancellationToken()) : Task.CompletedTask;
 
         /// <inheritdoc/>
         /// <remarks>


### PR DESCRIPTION
Unit tests were taking 10 seconds, which is crazy, so I fixed the timeout on the EnsureHealthCheck to have an upper limit of 60 seconds to be safe, but it expects a shorter timeout to be set by the caller of InitializeAsync if desired, so the tests set the timeout to 110ms, which is two cycles of the health checks plus a small buffer. This drops the unit test execution time down to less than a second.

Integration tests _can_ be long, but a minute seemed a little ridiculous, so I optimized some of the theories into facts which facts that can use Assert.All to get the same effect, but reduce the overhead. This dropped tests from 1 minute 10 seconds to 20-30 seconds.

Removed default timeouts, they can be set by the consumers using a timeout cancellation token, so it's best not to guess timeouts ourselves.

Addresses #58 