### PR TITLE
Added ability to create external network aliases

### DIFF
--- a/Mittons.Fixtures/Docker/Attributes/NetworkAliasAttribute.cs
+++ b/Mittons.Fixtures/Docker/Attributes/NetworkAliasAttribute.cs
@@ -9,10 +9,18 @@ namespace Mittons.Fixtures.Docker.Attributes
 
         public string Alias { get; }
 
+        public bool IsExternalNetwork { get; }
+
         public NetworkAliasAttribute(string networkName, string alias)
+            : this(networkName, alias, false)
+        {
+        }
+
+        public NetworkAliasAttribute(string networkName, string alias, bool isExternalNetwork)
         {
             NetworkName = networkName;
             Alias = alias;
+            IsExternalNetwork = isExternalNetwork;
         }
     }
 }

--- a/Mittons.Fixtures/Docker/Containers/Container.cs
+++ b/Mittons.Fixtures/Docker/Containers/Container.cs
@@ -66,7 +66,9 @@ namespace Mittons.Fixtures.Docker.Containers
 
             foreach (var networkAlias in _networks)
             {
-                await _networkGateway.ConnectAsync($"{networkAlias.NetworkName}-{_instanceId}", Id, networkAlias.Alias, cancellationToken).ConfigureAwait(false);
+                var networkName = networkAlias.IsExternalNetwork ? networkAlias.NetworkName : $"{networkAlias.NetworkName}-{_instanceId}";
+
+                await _networkGateway.ConnectAsync(networkName, Id, networkAlias.Alias, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/Mittons.Fixtures/Mittons.Fixtures.csproj
+++ b/Mittons.Fixtures/Mittons.Fixtures.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Mittons.Fixtures</PackageId>
-    <PackageVersion>1.0.0-rc.2</PackageVersion>
+    <PackageVersion>1.0.0-rc.3</PackageVersion>
     <Authors>Kenneth Mitton</Authors>
     <Description>Provides fixtures for defining test environments used in integration/system/end-to-end testing.</Description>
     <Copyright>Copyright (c) Kenneth Mitton 2021</Copyright>


### PR DESCRIPTION
Added a boolean indicator for whether a network alias should be applied to an external network, or an internal. When internal, then the network name is appended with the run instance id.