### PR TITLE
Updated healthcheck attribute to use valid types

### DIFF
--- a/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
@@ -432,7 +432,7 @@ public class ContainerTests
             [Theory]
             [InlineData(1)]
             [InlineData(8)]
-            public async Task InitializeAsync_WhenHealthCheckIntervalIsSet_ExpectHealthIntervalToBeApplied(int seconds)
+            public async Task InitializeAsync_WhenHealthCheckIntervalIsSet_ExpectHealthIntervalToBeApplied(byte seconds)
             {
                 // Arrange
                 var containerGatewayMock = new Mock<IContainerGateway>();
@@ -472,7 +472,7 @@ public class ContainerTests
             [Theory]
             [InlineData(1)]
             [InlineData(8)]
-            public async Task InitializeAsync_WhenHealthCheckTimeoutIsSet_ExpectHealthTimeoutToBeApplied(int seconds)
+            public async Task InitializeAsync_WhenHealthCheckTimeoutIsSet_ExpectHealthTimeoutToBeApplied(byte seconds)
             {
                 // Arrange
                 var containerGatewayMock = new Mock<IContainerGateway>();
@@ -512,7 +512,7 @@ public class ContainerTests
             [Theory]
             [InlineData(1)]
             [InlineData(8)]
-            public async Task InitializeAsync_WhenHealthCheckStartPeriodIsSet_ExpectHealthCheckStartPeriodToBeApplied(int seconds)
+            public async Task InitializeAsync_WhenHealthCheckStartPeriodIsSet_ExpectHealthCheckStartPeriodToBeApplied(byte seconds)
             {
                 // Arrange
                 var containerGatewayMock = new Mock<IContainerGateway>();
@@ -553,7 +553,7 @@ public class ContainerTests
             [InlineData(1)]
             [InlineData(2)]
             [InlineData(20)]
-            public async Task InitializeAsync_WhenHealthRetriesIsSet_ExpectHealthRetriesToBeApplied(int retries)
+            public async Task InitializeAsync_WhenHealthRetriesIsSet_ExpectHealthRetriesToBeApplied(byte retries)
             {
                 // Arrange
                 var containerGatewayMock = new Mock<IContainerGateway>();

--- a/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
@@ -358,9 +358,9 @@ public class ContainerTests
                         {
                             Disabled = true,
                             Command = "test",
-                            Interval = TimeSpan.FromSeconds(1),
-                            Timeout = TimeSpan.FromSeconds(1),
-                            StartPeriod = TimeSpan.FromSeconds(1),
+                            Interval = 1,
+                            Timeout = 1,
+                            StartPeriod = 1,
                             Retries = 1
                         },
                         new RunAttribute()
@@ -430,12 +430,9 @@ public class ContainerTests
             }
 
             [Theory]
-            [InlineData(250, 1)]
-            [InlineData(500, 1)]
-            [InlineData(750, 1)]
-            [InlineData(1000, 1)]
-            [InlineData(7500, 8)]
-            public async Task InitializeAsync_WhenHealthCheckIntervalIsSet_ExpectHealthIntervalToBeApplied(int milliseconds, int seconds)
+            [InlineData(1)]
+            [InlineData(8)]
+            public async Task InitializeAsync_WhenHealthCheckIntervalIsSet_ExpectHealthIntervalToBeApplied(int seconds)
             {
                 // Arrange
                 var containerGatewayMock = new Mock<IContainerGateway>();
@@ -452,7 +449,7 @@ public class ContainerTests
                     {
                         new ImageAttribute(string.Empty),
                         new CommandAttribute(string.Empty),
-                        new HealthCheckAttribute { Interval = TimeSpan.FromMilliseconds(milliseconds) },
+                        new HealthCheckAttribute { Interval = seconds },
                         new RunAttribute()
                     });
                 _containers.Add(container);
@@ -473,12 +470,9 @@ public class ContainerTests
             }
 
             [Theory]
-            [InlineData(250, 1)]
-            [InlineData(500, 1)]
-            [InlineData(750, 1)]
-            [InlineData(1000, 1)]
-            [InlineData(7500, 8)]
-            public async Task InitializeAsync_WhenHealthCheckTimeoutIsSet_ExpectHealthTimeoutToBeApplied(int milliseconds, int seconds)
+            [InlineData(1)]
+            [InlineData(8)]
+            public async Task InitializeAsync_WhenHealthCheckTimeoutIsSet_ExpectHealthTimeoutToBeApplied(int seconds)
             {
                 // Arrange
                 var containerGatewayMock = new Mock<IContainerGateway>();
@@ -495,7 +489,7 @@ public class ContainerTests
                     {
                         new ImageAttribute(string.Empty),
                         new CommandAttribute(string.Empty),
-                        new HealthCheckAttribute { Timeout = TimeSpan.FromMilliseconds(milliseconds) },
+                        new HealthCheckAttribute { Timeout = seconds },
                         new RunAttribute()
                     });
                 _containers.Add(container);
@@ -516,12 +510,9 @@ public class ContainerTests
             }
 
             [Theory]
-            [InlineData(250, 1)]
-            [InlineData(500, 1)]
-            [InlineData(750, 1)]
-            [InlineData(1000, 1)]
-            [InlineData(7500, 8)]
-            public async Task InitializeAsync_WhenHealthCheckStartPeriodIsSet_ExpectHealthCheckStartPeriodToBeApplied(int milliseconds, int seconds)
+            [InlineData(1)]
+            [InlineData(8)]
+            public async Task InitializeAsync_WhenHealthCheckStartPeriodIsSet_ExpectHealthCheckStartPeriodToBeApplied(int seconds)
             {
                 // Arrange
                 var containerGatewayMock = new Mock<IContainerGateway>();
@@ -538,7 +529,7 @@ public class ContainerTests
                     {
                         new ImageAttribute(string.Empty),
                         new CommandAttribute(string.Empty),
-                        new HealthCheckAttribute { StartPeriod = TimeSpan.FromMilliseconds(milliseconds) },
+                        new HealthCheckAttribute { StartPeriod = seconds },
                         new RunAttribute()
                     });
                 _containers.Add(container);

--- a/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Containers/ContainerTests.cs
@@ -589,6 +589,152 @@ public class ContainerTests
                         )
                     );
             }
+
+            [Fact]
+            public async Task InitializeAsync_WhenHealthDetailsAreNotSet_ExpectNoHealthParametersToBeApplied()
+            {
+                // Arrange
+                var containerGatewayMock = new Mock<IContainerGateway>();
+                containerGatewayMock.Setup(x => x.GetHealthStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(HealthStatus.Running);
+
+                var networkGatewayMock = new Mock<INetworkGateway>();
+
+                var container = new Container(
+                    containerGatewayMock.Object,
+                    networkGatewayMock.Object,
+                    Guid.Empty,
+                    new Attribute[]
+                    {
+                        new ImageAttribute(string.Empty),
+                        new CommandAttribute(string.Empty),
+                        new HealthCheckAttribute(),
+                        new RunAttribute()
+                    });
+                _containers.Add(container);
+
+                var healthParameters = new[]
+                {
+                    "--no-healthcheck",
+                    "--health-cmd",
+                    "--health-interval",
+                    "--health-timeout",
+                    "--health-start-period",
+                    "--health-retries",
+                };
+
+                // Act
+                await container.InitializeAsync(CancellationToken.None);
+
+                // Assert
+                containerGatewayMock.Verify(
+                        x =>
+                        x.RunAsync(
+                            string.Empty,
+                            string.Empty,
+                            It.Is<IEnumerable<Option>>(x => x.Any(y => healthParameters.Contains(y.Name))),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Never
+                    );
+            }
+
+            [Fact]
+            public async Task InitializeAsync_WhenHealthDetailsAreSetToZero_ExpectNoHealthParametersToBeApplied()
+            {
+                // Arrange
+                var containerGatewayMock = new Mock<IContainerGateway>();
+                containerGatewayMock.Setup(x => x.GetHealthStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(HealthStatus.Running);
+
+                var networkGatewayMock = new Mock<INetworkGateway>();
+
+                var container = new Container(
+                    containerGatewayMock.Object,
+                    networkGatewayMock.Object,
+                    Guid.Empty,
+                    new Attribute[]
+                    {
+                        new ImageAttribute(string.Empty),
+                        new CommandAttribute(string.Empty),
+                        new HealthCheckAttribute { Interval = 0, Retries = 0, StartPeriod = 0, Timeout = 0 },
+                        new RunAttribute()
+                    });
+                _containers.Add(container);
+
+                var healthParameters = new[]
+                {
+                    "--no-healthcheck",
+                    "--health-cmd",
+                    "--health-interval",
+                    "--health-timeout",
+                    "--health-start-period",
+                    "--health-retries",
+                };
+
+                // Act
+                await container.InitializeAsync(CancellationToken.None);
+
+                // Assert
+                containerGatewayMock.Verify(
+                        x =>
+                        x.RunAsync(
+                            string.Empty,
+                            string.Empty,
+                            It.Is<IEnumerable<Option>>(x => x.Any(y => healthParameters.Contains(y.Name))),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Never
+                    );
+            }
+
+            [Fact]
+            public async Task InitializeAsync_WhenNoHealthAttributeIsProvided_ExpectNoHealthParametersToBeApplied()
+            {
+                // Arrange
+                var containerGatewayMock = new Mock<IContainerGateway>();
+                containerGatewayMock.Setup(x => x.GetHealthStatusAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(HealthStatus.Running);
+
+                var networkGatewayMock = new Mock<INetworkGateway>();
+
+                var container = new Container(
+                    containerGatewayMock.Object,
+                    networkGatewayMock.Object,
+                    Guid.Empty,
+                    new Attribute[]
+                    {
+                        new ImageAttribute(string.Empty),
+                        new CommandAttribute(string.Empty),
+                        new RunAttribute()
+                    });
+                _containers.Add(container);
+
+                var healthParameters = new[]
+                {
+                    "--no-healthcheck",
+                    "--health-cmd",
+                    "--health-interval",
+                    "--health-timeout",
+                    "--health-start-period",
+                    "--health-retries",
+                };
+
+                // Act
+                await container.InitializeAsync(CancellationToken.None);
+
+                // Assert
+                containerGatewayMock.Verify(
+                        x =>
+                        x.RunAsync(
+                            string.Empty,
+                            string.Empty,
+                            It.Is<IEnumerable<Option>>(x => x.Any(y => healthParameters.Contains(y.Name))),
+                            It.IsAny<CancellationToken>()
+                        ),
+                        Times.Never
+                    );
+            }
         }
     }
 

--- a/Mittons.Fixtures.Tests.Unit/Docker/Containers/SftpContainerTests.cs
+++ b/Mittons.Fixtures.Tests.Unit/Docker/Containers/SftpContainerTests.cs
@@ -84,9 +84,9 @@ public class SftpContainerTests : BaseContainerTests
                         {
                             Disabled = false,
                             Command = "test",
-                            Interval = TimeSpan.FromSeconds(2),
-                            Timeout = TimeSpan.FromSeconds(2),
-                            StartPeriod = TimeSpan.FromSeconds(2),
+                            Interval = 2,
+                            Timeout = 2,
+                            StartPeriod = 2,
                             Retries = 1
                         }
                     }

--- a/Mittons.Fixtures/Docker/Attributes/HealthCheckAttribute.cs
+++ b/Mittons.Fixtures/Docker/Attributes/HealthCheckAttribute.cs
@@ -11,13 +11,13 @@ namespace Mittons.Fixtures.Docker.Attributes
 
         public string Command { get; set; }
 
-        public int Interval { get; set; }
+        public byte Interval { get; set; }
 
-        public int Timeout { get; set; }
+        public byte Timeout { get; set; }
 
-        public int StartPeriod { get; set; }
+        public byte StartPeriod { get; set; }
 
-        public int Retries { get; set; }
+        public byte Retries { get; set; }
 
         public IEnumerable<Option> Options
         {

--- a/Mittons.Fixtures/Docker/Attributes/HealthCheckAttribute.cs
+++ b/Mittons.Fixtures/Docker/Attributes/HealthCheckAttribute.cs
@@ -11,13 +11,13 @@ namespace Mittons.Fixtures.Docker.Attributes
 
         public string Command { get; set; }
 
-        public TimeSpan? Interval { get; set; }
+        public int Interval { get; set; }
 
-        public TimeSpan? Timeout { get; set; }
+        public int Timeout { get; set; }
 
-        public TimeSpan? StartPeriod { get; set; }
+        public int StartPeriod { get; set; }
 
-        public int? Retries { get; set; }
+        public int Retries { get; set; }
 
         public IEnumerable<Option> Options
         {
@@ -36,24 +36,24 @@ namespace Mittons.Fixtures.Docker.Attributes
                         options.Add(new Option { Name = "--health-cmd", Value = Command });
                     }
 
-                    if (Interval.HasValue)
+                    if (Interval > 0)
                     {
-                        options.Add(new Option { Name = "--health-interval", Value = $"{Math.Ceiling(Interval.Value.TotalSeconds)}s" });
+                        options.Add(new Option { Name = "--health-interval", Value = $"{Interval}s" });
                     }
 
-                    if (Timeout.HasValue)
+                    if (Timeout > 0)
                     {
-                        options.Add(new Option { Name = "--health-timeout", Value = $"{Math.Ceiling(Timeout.Value.TotalSeconds)}s" });
+                        options.Add(new Option { Name = "--health-timeout", Value = $"{Timeout}s" });
                     }
 
-                    if (StartPeriod.HasValue)
+                    if (StartPeriod > 0)
                     {
-                        options.Add(new Option { Name = "--health-start-period", Value = $"{Math.Ceiling(StartPeriod.Value.TotalSeconds)}s" });
+                        options.Add(new Option { Name = "--health-start-period", Value = $"{StartPeriod}s" });
                     }
 
-                    if (Retries.HasValue)
+                    if (Retries > 0)
                     {
-                        options.Add(new Option { Name = "--health-retries", Value = Retries.Value.ToString() });
+                        options.Add(new Option { Name = "--health-retries", Value = Retries.ToString() });
                     }
                 }
 

--- a/Mittons.Fixtures/Docker/Containers/SftpContainer.cs
+++ b/Mittons.Fixtures/Docker/Containers/SftpContainer.cs
@@ -136,9 +136,9 @@ namespace Mittons.Fixtures.Docker.Containers
                         {
                             Disabled = false,
                             Command = "ps aux | grep -v grep | grep sshd || exit 1",
-                            Interval = TimeSpan.FromSeconds(1),
-                            Timeout = TimeSpan.FromSeconds(1),
-                            StartPeriod = TimeSpan.FromSeconds(5),
+                            Interval = 1,
+                            Timeout = 1,
+                            StartPeriod = 5,
                             Retries = 3
                         }
                     }


### PR DESCRIPTION
TimeSpan? and int? are not valid for attributes, so updated to use valid types that can be resolved at compile time.